### PR TITLE
`secp256k1` Point Addition

### DIFF
--- a/miden/tests/integration/stdlib/math/secp256k1.rs
+++ b/miden/tests/integration/stdlib/math/secp256k1.rs
@@ -386,6 +386,161 @@ fn test_secp256k1_point_doubling() {
     let _ = test.get_last_stack_state();
 }
 
+#[test]
+fn test_secp256k1_point_addition() {
+    let source = "
+    use.std::math::secp256k1
+
+    # Given generator point of secp256k1 elliptic curve ( twice ), this routine first computes
+    # point addition of generator point with itself ( i.e. it's equivalent to point doubling ) 
+    # in projective coordinate & then asserts each coordinate limb-by-limb for ensuring correctness.
+    #
+    # Note, this test is not yet very generic i.e. it can't be generalized to work
+    # with any points generated from curve generator & test for correctness of execution
+    # of point addition assembly routine. This is what I'd like to make it, in sometime future.
+    proc.point_addition_test_wrapper.18
+        # push X1 -coordinate to memory
+        push.589179219.700212955.3610652250.1216225431
+        popw.local.0
+        push.2575427139.3909656392.2543798464.872223388
+        popw.local.1
+
+        # push Y1 -coordinate to memory
+        push.2382126429.522045005.2975770322.3554388962
+        popw.local.2
+        push.3477046559.3567616726.1891022234.2887369014
+        popw.local.3
+
+        # push Z1 -coordinate to memory
+        push.0.0.1.977
+        popw.local.4
+        push.0.0.0.0
+        popw.local.5
+
+        # push X2 -coordinate to memory
+        push.589179219.700212955.3610652250.1216225431
+        popw.local.6
+        push.2575427139.3909656392.2543798464.872223388
+        popw.local.7
+
+        # push Y2 -coordinate to memory
+        push.2382126429.522045005.2975770322.3554388962
+        popw.local.8
+        push.3477046559.3567616726.1891022234.2887369014
+        popw.local.9
+
+        # push Z2 -coordinate to memory
+        push.0.0.1.977
+        popw.local.10
+        push.0.0.0.0
+        popw.local.11
+
+        # input/ output memory addresses for point doubling purpose
+        push.env.locaddr.17
+        push.env.locaddr.16
+        push.env.locaddr.15
+        push.env.locaddr.14
+        push.env.locaddr.13
+        push.env.locaddr.12
+
+        push.env.locaddr.11
+        push.env.locaddr.10
+        push.env.locaddr.9
+        push.env.locaddr.8
+        push.env.locaddr.7
+        push.env.locaddr.6
+
+        push.env.locaddr.5
+        push.env.locaddr.4
+        push.env.locaddr.3
+        push.env.locaddr.2
+        push.env.locaddr.1
+        push.env.locaddr.0
+
+        # elliptic curve point addition
+        exec.secp256k1::point_addition
+
+        # --- start asserting X3 ---
+        pushw.mem
+
+        u32eq.474728642
+        assert
+        u32eq.4256012599
+        assert
+        u32eq.2072183026
+        assert
+        u32eq.3437933890
+        assert
+
+        pushw.mem
+
+        u32eq.4191201175
+        assert
+        u32eq.1644336685
+        assert
+        u32eq.3276311816
+        assert
+        u32eq.617223735
+        assert
+        # --- end asserting X3 ---
+
+        # --- start asserting Y3 ---
+        pushw.mem
+
+        u32eq.3875396767
+        assert
+        u32eq.483526712
+        assert
+        u32eq.3043178571
+        assert
+        u32eq.2826781693
+        assert
+
+        pushw.mem
+
+        u32eq.2758035882
+        assert
+        u32eq.3425160008
+        assert
+        u32eq.524996660
+        assert
+        u32eq.1440660280
+        assert
+        # --- end asserting Y3 ---
+
+        # --- start asserting Z3 ---
+        pushw.mem
+
+        u32eq.2545792257
+        assert
+        u32eq.4082826636
+        assert
+        u32eq.1673463056
+        assert
+        u32eq.2688095969
+        assert
+
+        pushw.mem
+
+        u32eq.2687252166
+        assert
+        u32eq.3884180958
+        assert
+        u32eq.1848170264
+        assert
+        u32eq.579919648
+        assert
+        # --- end asserting Z3 ---
+    end
+
+    begin
+        exec.point_addition_test_wrapper
+    end";
+
+    let test = build_test!(source, &[]);
+    let _ = test.get_last_stack_state();
+}
+
 fn mac(a: u32, b: u32, c: u32, carry: u32) -> (u32, u32) {
     let tmp = a as u64 + (b as u64 * c as u64) + carry as u64;
     ((tmp >> 32) as u32, tmp as u32)

--- a/stdlib/asm/math/secp256k1.masm
+++ b/stdlib/asm/math/secp256k1.masm
@@ -732,3 +732,454 @@ export.point_doubling.12
   movup.4
   popw.mem          # write z3[4..8] to memory
 end
+
+# Given two secp256k1 points in projective coordinate system ( i.e. with x, y, z -coordinates
+# as secp256k1 prime field elements, represented in Montgomery form, each coordinate using eight 32 -bit limbs ),
+# this routine adds those two points on elliptic curve, using exception-free addition formula from
+# algorithm 7 of https://eprint.iacr.org/2015/1060.pdf, while following prototype
+# implementation https://github.com/itzmeanjan/secp256k1/blob/ec3652a/point.py#L60-L115
+# 
+# Input:
+#
+# 18 memory addresses on stack such that first 6 memory addresses are for first input point, next 6
+# memory addresses holding x, y, z -coordinates of second input point & last 6 addresses are for storing 
+# resulting point ( addition of two input points ).
+#
+# Expected stack during invokation of this routine:
+#
+#   [x1_addr[0..4], x1_addr[4..8], y1_addr[0..4], y1_addr[4..8], z1_addr[0..4], z1_addr[4..8], 
+#     x2_addr[0..4], x2_addr[4..8], y2_addr[0..4], y2_addr[4..8], z2_addr[0..4], z2_addr[4..8],
+#       x3_addr[0..4], x3_addr[4..8], y3_addr[0..4], y3_addr[4..8], z3_addr[0..4], z3_addr[4..8]]
+#
+# Note, (X1, Y1, Z1)    => input point 1
+#       (X2, Y2, Z2)    => input point 2
+#       (X3, Y3, Z3)    => output point
+#
+# Output:
+#
+# Last 6 memory addresses of 18 input memory addresses which were provided during invokation, where resulting elliptic curve
+# point is kept in similar form. For seeing X3, Y3, Z3 -coordinates of doubled point, one needs to read from
+# those 6 memory addresses.
+#
+# Stack at end of execution of routine looks like
+#
+#   [x3_addr[0..4], x3_addr[4..8], y3_addr[0..4], y3_addr[4..8], z3_addr[0..4], z3_addr[4..8]]
+export.point_addition.16
+  dup.6
+  dup.8
+
+  pushw.mem
+  movup.4
+  pushw.mem # x2 on stack top
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # x1 on stack top
+
+  exec.u256_mod_mul # = t0
+
+  popw.local.0
+  popw.local.1 # cache t0
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # y2 on stack top
+
+  dup.10
+  dup.12
+
+  pushw.mem
+  movup.4
+  pushw.mem # y1 on stack top
+
+  exec.u256_mod_mul # = t1
+
+  popw.local.2
+  popw.local.3 # cache t1
+
+  dup.10
+  dup.12
+
+  pushw.mem
+  movup.4
+  pushw.mem # z2 on stack top
+
+  dup.12
+  dup.14
+
+  pushw.mem
+  movup.4
+  pushw.mem # z1 on stack top
+
+  exec.u256_mod_mul # = t2
+
+  popw.local.4
+  popw.local.5 # cache t2
+
+  dup.2
+  dup.4
+
+  pushw.mem
+  movup.4
+  pushw.mem # y1 on stack top
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # x1 on stack top
+
+  exec.u256_mod_add # = t3
+
+  popw.local.6
+  popw.local.7 # cache t3
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # y2 on stack top
+
+  dup.15
+  dup.15
+  swap
+
+  pushw.mem
+  movup.4
+  pushw.mem # x2 on stack top
+  
+  exec.u256_mod_add # = t4
+
+  pushw.local.7
+  pushw.local.6 # t3 loaded back
+
+  exec.u256_mod_mul # = t3
+
+  popw.local.6
+  popw.local.7 # cache t3
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_add # = t4
+
+  pushw.local.7
+  pushw.local.6 # t3 loaded back
+
+  exec.u256_mod_sub # = t3
+
+  popw.local.6
+  popw.local.7 # cache t3
+
+  dup.2
+  dup.4
+
+  pushw.mem
+  movup.4
+  pushw.mem # y1 on stack top
+
+  dup.12
+  dup.14
+
+  pushw.mem
+  movup.4
+  pushw.mem # z1 on stack top
+
+  exec.u256_mod_add # = t4
+
+  popw.local.8
+  popw.local.9 # cache t4
+
+  dup.11
+  dup.11
+
+  dup.10
+  dup.12
+
+  pushw.mem
+  movup.4
+  pushw.mem # y2 on stack top
+
+  movup.8
+  movup.9
+
+  pushw.mem
+  movup.4
+  pushw.mem # z2 on stack top
+
+  exec.u256_mod_add # = x3
+
+  pushw.local.9
+  pushw.local.8 # t4 loaded back
+
+  exec.u256_mod_mul # = t4
+
+  popw.local.8
+  popw.local.9 # cache t4
+
+  pushw.local.5
+  pushw.local.4 # t2 loaded back
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  exec.u256_mod_add # = x3
+
+  pushw.local.9
+  pushw.local.8 # t4 loaded back
+
+  exec.u256_mod_sub # = t4
+
+  popw.local.8
+  popw.local.9 # cache t4
+
+  dup.4
+  dup.6
+
+  pushw.mem
+  movup.4
+  pushw.mem # z1 on stack top
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # x1 on stack top
+
+  exec.u256_mod_add # = x3
+
+  popw.local.10
+  popw.local.11 # cache x3
+
+  dup.10
+  dup.12
+
+  pushw.mem
+  movup.4
+  pushw.mem # z2 on stack top
+
+  dup.15
+  dup.15
+  swap
+
+  pushw.mem
+  movup.4
+  pushw.mem # x2 on stack top
+
+  exec.u256_mod_add # = y3
+
+  pushw.local.11
+  pushw.local.10 # x3 loaded back
+
+  exec.u256_mod_mul # = x3
+
+  popw.local.10
+  popw.local.11 # cache x3
+
+  pushw.local.5
+  pushw.local.4 # t2 loaded back
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_add # = y3
+
+  pushw.local.11
+  pushw.local.10 # x3 loaded back
+
+  exec.u256_mod_sub # = y3
+
+  popw.local.12
+  popw.local.13 # cache y3
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  dupw.1
+  dupw.1
+
+  exec.u256_mod_add # = x3
+
+  storew.local.10
+  swapw
+  storew.local.11
+  swapw # cache x3
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_add # = t0
+
+  popw.local.0
+  popw.local.1 # cache t0
+
+  push.0.0.0.0
+  push.0.0.21.20517 # b3 on stack top
+
+  pushw.local.5
+  pushw.local.4 # t2 loaded back
+
+  exec.u256_mod_mul # = t2
+
+  storew.local.4
+  swapw
+  storew.local.5
+  swapw # cache t2
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  exec.u256_mod_add # = z3
+
+  popw.local.14
+  popw.local.15 # cache z3
+
+  pushw.local.5
+  pushw.local.4 # t2 loaded back
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  exec.u256_mod_sub # = t1
+
+  popw.local.2
+  popw.local.3 # cache t1
+
+  push.0.0.0.0
+  push.0.0.21.20517 # b3 on stack top
+
+  pushw.local.13
+  pushw.local.12 # y3 loaded back
+
+  exec.u256_mod_mul # = y3
+
+  storew.local.12
+  swapw
+  storew.local.13
+  swapw # cache y3
+
+  pushw.local.9
+  pushw.local.8 # t4 loaded back
+
+  exec.u256_mod_mul # = x3
+
+  popw.local.10
+  popw.local.11 # cache x3
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  pushw.local.7
+  pushw.local.6 # t3 loaded back
+
+  exec.u256_mod_mul # = t2
+
+  pushw.local.11
+  pushw.local.10 # x3 loaded back
+
+  exec.u256_mod_neg
+  exec.u256_mod_add # = x3
+
+  popw.local.10
+  popw.local.11 # cache x3
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  pushw.local.13
+  pushw.local.12 # y3 loaded back
+
+  exec.u256_mod_mul # = y3
+
+  popw.local.12
+  popw.local.13 # cache y3
+
+  pushw.local.15
+  pushw.local.14 # z3 loaded back
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  exec.u256_mod_mul # = t1
+
+  pushw.local.13
+  pushw.local.12 # y3 loaded back
+
+  exec.u256_mod_add # = y3
+
+  popw.local.12
+  popw.local.13 # cache y3
+
+  pushw.local.7
+  pushw.local.6 # t3 loaded back
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_mul # = t0
+
+  popw.local.0
+  popw.local.1 # cache t0
+
+  pushw.local.9
+  pushw.local.8 # t4 loaded back
+
+  pushw.local.15
+  pushw.local.14 # z3 loaded back
+
+  exec.u256_mod_mul # = z3
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_add # = z3
+
+  popw.local.14
+  popw.local.15 # cache z3
+
+  dropw
+  dropw
+  dropw
+
+  dup
+  pushw.local.10
+  movup.4
+  popw.mem          # write x3[0..4] to memory
+
+  dup.1
+  pushw.local.11
+  movup.4
+  popw.mem          # write x3[4..8] to memory
+
+  dup.2
+  pushw.local.12
+  movup.4
+  popw.mem          # write y3[0..4] to memory
+
+  dup.3
+  pushw.local.13
+  movup.4
+  popw.mem          # write y3[4..8] to memory
+
+  dup.4
+  pushw.local.14
+  movup.4
+  popw.mem          # write z3[0..4] to memory
+
+  dup.5
+  pushw.local.15
+  movup.4
+  popw.mem          # write z3[4..8] to memory
+end

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -10093,6 +10093,457 @@ export.point_doubling.12
   movup.4
   popw.mem          # write z3[4..8] to memory
 end
+
+# Given two secp256k1 points in projective coordinate system ( i.e. with x, y, z -coordinates
+# as secp256k1 prime field elements, represented in Montgomery form, each coordinate using eight 32 -bit limbs ),
+# this routine adds those two points on elliptic curve, using exception-free addition formula from
+# algorithm 7 of https://eprint.iacr.org/2015/1060.pdf, while following prototype
+# implementation https://github.com/itzmeanjan/secp256k1/blob/ec3652a/point.py#L60-L115
+# 
+# Input:
+#
+# 18 memory addresses on stack such that first 6 memory addresses are for first input point, next 6
+# memory addresses holding x, y, z -coordinates of second input point & last 6 addresses are for storing 
+# resulting point ( addition of two input points ).
+#
+# Expected stack during invokation of this routine:
+#
+#   [x1_addr[0..4], x1_addr[4..8], y1_addr[0..4], y1_addr[4..8], z1_addr[0..4], z1_addr[4..8], 
+#     x2_addr[0..4], x2_addr[4..8], y2_addr[0..4], y2_addr[4..8], z2_addr[0..4], z2_addr[4..8],
+#       x3_addr[0..4], x3_addr[4..8], y3_addr[0..4], y3_addr[4..8], z3_addr[0..4], z3_addr[4..8]]
+#
+# Note, (X1, Y1, Z1)    => input point 1
+#       (X2, Y2, Z2)    => input point 2
+#       (X3, Y3, Z3)    => output point
+#
+# Output:
+#
+# Last 6 memory addresses of 18 input memory addresses which were provided during invokation, where resulting elliptic curve
+# point is kept in similar form. For seeing X3, Y3, Z3 -coordinates of doubled point, one needs to read from
+# those 6 memory addresses.
+#
+# Stack at end of execution of routine looks like
+#
+#   [x3_addr[0..4], x3_addr[4..8], y3_addr[0..4], y3_addr[4..8], z3_addr[0..4], z3_addr[4..8]]
+export.point_addition.16
+  dup.6
+  dup.8
+
+  pushw.mem
+  movup.4
+  pushw.mem # x2 on stack top
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # x1 on stack top
+
+  exec.u256_mod_mul # = t0
+
+  popw.local.0
+  popw.local.1 # cache t0
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # y2 on stack top
+
+  dup.10
+  dup.12
+
+  pushw.mem
+  movup.4
+  pushw.mem # y1 on stack top
+
+  exec.u256_mod_mul # = t1
+
+  popw.local.2
+  popw.local.3 # cache t1
+
+  dup.10
+  dup.12
+
+  pushw.mem
+  movup.4
+  pushw.mem # z2 on stack top
+
+  dup.12
+  dup.14
+
+  pushw.mem
+  movup.4
+  pushw.mem # z1 on stack top
+
+  exec.u256_mod_mul # = t2
+
+  popw.local.4
+  popw.local.5 # cache t2
+
+  dup.2
+  dup.4
+
+  pushw.mem
+  movup.4
+  pushw.mem # y1 on stack top
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # x1 on stack top
+
+  exec.u256_mod_add # = t3
+
+  popw.local.6
+  popw.local.7 # cache t3
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # y2 on stack top
+
+  dup.15
+  dup.15
+  swap
+
+  pushw.mem
+  movup.4
+  pushw.mem # x2 on stack top
+  
+  exec.u256_mod_add # = t4
+
+  pushw.local.7
+  pushw.local.6 # t3 loaded back
+
+  exec.u256_mod_mul # = t3
+
+  popw.local.6
+  popw.local.7 # cache t3
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_add # = t4
+
+  pushw.local.7
+  pushw.local.6 # t3 loaded back
+
+  exec.u256_mod_sub # = t3
+
+  popw.local.6
+  popw.local.7 # cache t3
+
+  dup.2
+  dup.4
+
+  pushw.mem
+  movup.4
+  pushw.mem # y1 on stack top
+
+  dup.12
+  dup.14
+
+  pushw.mem
+  movup.4
+  pushw.mem # z1 on stack top
+
+  exec.u256_mod_add # = t4
+
+  popw.local.8
+  popw.local.9 # cache t4
+
+  dup.11
+  dup.11
+
+  dup.10
+  dup.12
+
+  pushw.mem
+  movup.4
+  pushw.mem # y2 on stack top
+
+  movup.8
+  movup.9
+
+  pushw.mem
+  movup.4
+  pushw.mem # z2 on stack top
+
+  exec.u256_mod_add # = x3
+
+  pushw.local.9
+  pushw.local.8 # t4 loaded back
+
+  exec.u256_mod_mul # = t4
+
+  popw.local.8
+  popw.local.9 # cache t4
+
+  pushw.local.5
+  pushw.local.4 # t2 loaded back
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  exec.u256_mod_add # = x3
+
+  pushw.local.9
+  pushw.local.8 # t4 loaded back
+
+  exec.u256_mod_sub # = t4
+
+  popw.local.8
+  popw.local.9 # cache t4
+
+  dup.4
+  dup.6
+
+  pushw.mem
+  movup.4
+  pushw.mem # z1 on stack top
+
+  dup.8
+  dup.10
+
+  pushw.mem
+  movup.4
+  pushw.mem # x1 on stack top
+
+  exec.u256_mod_add # = x3
+
+  popw.local.10
+  popw.local.11 # cache x3
+
+  dup.10
+  dup.12
+
+  pushw.mem
+  movup.4
+  pushw.mem # z2 on stack top
+
+  dup.15
+  dup.15
+  swap
+
+  pushw.mem
+  movup.4
+  pushw.mem # x2 on stack top
+
+  exec.u256_mod_add # = y3
+
+  pushw.local.11
+  pushw.local.10 # x3 loaded back
+
+  exec.u256_mod_mul # = x3
+
+  popw.local.10
+  popw.local.11 # cache x3
+
+  pushw.local.5
+  pushw.local.4 # t2 loaded back
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_add # = y3
+
+  pushw.local.11
+  pushw.local.10 # x3 loaded back
+
+  exec.u256_mod_sub # = y3
+
+  popw.local.12
+  popw.local.13 # cache y3
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  dupw.1
+  dupw.1
+
+  exec.u256_mod_add # = x3
+
+  storew.local.10
+  swapw
+  storew.local.11
+  swapw # cache x3
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_add # = t0
+
+  popw.local.0
+  popw.local.1 # cache t0
+
+  push.0.0.0.0
+  push.0.0.21.20517 # b3 on stack top
+
+  pushw.local.5
+  pushw.local.4 # t2 loaded back
+
+  exec.u256_mod_mul # = t2
+
+  storew.local.4
+  swapw
+  storew.local.5
+  swapw # cache t2
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  exec.u256_mod_add # = z3
+
+  popw.local.14
+  popw.local.15 # cache z3
+
+  pushw.local.5
+  pushw.local.4 # t2 loaded back
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  exec.u256_mod_sub # = t1
+
+  popw.local.2
+  popw.local.3 # cache t1
+
+  push.0.0.0.0
+  push.0.0.21.20517 # b3 on stack top
+
+  pushw.local.13
+  pushw.local.12 # y3 loaded back
+
+  exec.u256_mod_mul # = y3
+
+  storew.local.12
+  swapw
+  storew.local.13
+  swapw # cache y3
+
+  pushw.local.9
+  pushw.local.8 # t4 loaded back
+
+  exec.u256_mod_mul # = x3
+
+  popw.local.10
+  popw.local.11 # cache x3
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  pushw.local.7
+  pushw.local.6 # t3 loaded back
+
+  exec.u256_mod_mul # = t2
+
+  pushw.local.11
+  pushw.local.10 # x3 loaded back
+
+  exec.u256_mod_neg
+  exec.u256_mod_add # = x3
+
+  popw.local.10
+  popw.local.11 # cache x3
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  pushw.local.13
+  pushw.local.12 # y3 loaded back
+
+  exec.u256_mod_mul # = y3
+
+  popw.local.12
+  popw.local.13 # cache y3
+
+  pushw.local.15
+  pushw.local.14 # z3 loaded back
+
+  pushw.local.3
+  pushw.local.2 # t1 loaded back
+
+  exec.u256_mod_mul # = t1
+
+  pushw.local.13
+  pushw.local.12 # y3 loaded back
+
+  exec.u256_mod_add # = y3
+
+  popw.local.12
+  popw.local.13 # cache y3
+
+  pushw.local.7
+  pushw.local.6 # t3 loaded back
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_mul # = t0
+
+  popw.local.0
+  popw.local.1 # cache t0
+
+  pushw.local.9
+  pushw.local.8 # t4 loaded back
+
+  pushw.local.15
+  pushw.local.14 # z3 loaded back
+
+  exec.u256_mod_mul # = z3
+
+  pushw.local.1
+  pushw.local.0 # t0 loaded back
+
+  exec.u256_mod_add # = z3
+
+  popw.local.14
+  popw.local.15 # cache z3
+
+  dropw
+  dropw
+  dropw
+
+  dup
+  pushw.local.10
+  movup.4
+  popw.mem          # write x3[0..4] to memory
+
+  dup.1
+  pushw.local.11
+  movup.4
+  popw.mem          # write x3[4..8] to memory
+
+  dup.2
+  pushw.local.12
+  movup.4
+  popw.mem          # write y3[0..4] to memory
+
+  dup.3
+  pushw.local.13
+  movup.4
+  popw.mem          # write y3[4..8] to memory
+
+  dup.4
+  pushw.local.14
+  movup.4
+  popw.mem          # write z3[0..4] to memory
+
+  dup.5
+  pushw.local.15
+  movup.4
+  popw.mem          # write z3[4..8] to memory
+end
 "),
 // ----- std::math::u256 --------------------------------------------------------------------------
 ("std::math::u256", "export.add_unsafe


### PR DESCRIPTION
- Miden assembly routine for adding two secp256k1 elliptic curve points, using exception-free formula ( see [here](https://github.com/itzmeanjan/secp256k1/blob/ec3652afe8ed72b29b0e39273a876a898316fb9a/point.py#L60-L115) )
- Test functional correctness of aforementioned routine

Miden VM cycles for computing point addition: **34,653**