### PR TITLE
`secp256k1` Point Multiplication

### DIFF
--- a/miden/tests/integration/stdlib/math/secp256k1.rs
+++ b/miden/tests/integration/stdlib/math/secp256k1.rs
@@ -541,6 +541,116 @@ fn test_secp256k1_point_addition() {
     let _ = test.get_last_stack_state();
 }
 
+#[test]
+fn test_secp256k1_point_multiplication() {
+    let source = "
+    use.std::math::secp256k1
+
+    # Given 256 -bit scalar in radix-2^32 form ( i.e. 8 limbs, each of 32 -bit width ), 
+    # this routine first multiplies the identity point of group ( i.e. 0, 1, 0 in projective 
+    # coordinate system ), by (given) scalar and then asserts for correctness with known answer.
+    #
+    # Note, this test is not yet very generic i.e. it can't be generalized to work
+    # with any 256 -bit random scalar & test for correctness of execution of point 
+    # multiplication assembly routine. This is what I'd like to make it, in sometime future.
+    proc.point_multiplication_test_wrapper.6
+        # resulting point ( in projective coordinate system ) 
+        # will be stored in these addresses
+        push.env.locaddr.5
+        push.env.locaddr.4
+        push.env.locaddr.3
+        push.env.locaddr.2
+        push.env.locaddr.1
+        push.env.locaddr.0
+
+        # scalar
+        push.3754378978.2737387451.3951838026.2457684815
+        push.1793611799.2969588298.2075099376.2301743426
+
+        # elliptic curve point multiplication
+        exec.secp256k1::point_mul
+
+        # --- start asserting X ---
+        pushw.mem
+
+        u32eq.1096602412
+        assert
+        u32eq.1336778744
+        assert
+        u32eq.4237851429
+        assert
+        u32eq.2379704491
+        assert
+
+        pushw.mem
+
+        u32eq.2174658910
+        assert
+        u32eq.1179196601
+        assert
+        u32eq.696486755
+        assert
+        u32eq.2826869248
+        assert
+        # --- end asserting X ---
+
+        # --- start asserting Y ---
+        pushw.mem
+
+        u32eq.3362845704
+        assert
+        u32eq.129965728
+        assert
+        u32eq.1311711770
+        assert
+        u32eq.3674781461
+        assert
+
+        pushw.mem
+
+        u32eq.3620120701
+        assert
+        u32eq.1257229422
+        assert
+        u32eq.162674263
+        assert
+        u32eq.1366999099
+        assert
+        # --- end asserting Y ---
+
+        # --- start asserting Z ---
+        pushw.mem
+
+        u32eq.440013615
+        assert
+        u32eq.548226205
+        assert
+        u32eq.868197170
+        assert
+        u32eq.3947728772
+        assert
+
+        pushw.mem
+
+        u32eq.2287684084
+        assert
+        u32eq.3056380747
+        assert
+        u32eq.2298699306
+        assert
+        u32eq.2987928230
+        assert
+        # --- end asserting Z ---
+    end
+
+    begin
+        exec.point_multiplication_test_wrapper
+    end";
+
+    let test = build_test!(source, &[]);
+    let _ = test.get_last_stack_state();
+}
+
 fn mac(a: u32, b: u32, c: u32, carry: u32) -> (u32, u32) {
     let tmp = a as u64 + (b as u64 * c as u64) + carry as u64;
     ((tmp >> 32) as u32, tmp as u32)

--- a/stdlib/asm/math/secp256k1.masm
+++ b/stdlib/asm/math/secp256k1.masm
@@ -521,7 +521,7 @@ end
 # coordinate is represented in Montgomery form, as eight 32 -bit limbs. Note, this is where
 # output will be written, so called is expected to read doubled point from last 6 memory addresses.
 #
-# Expected stack during invokation of this routine:
+# Expected stack during invocation of this routine:
 #
 #   [x_addr[0..4], x_addr[4..8], y_addr[0..4], y_addr[4..8], z_addr[0..4], z_addr[4..8], 
 #     x3_addr[0..4], x3_addr[4..8], y3_addr[0..4], y3_addr[4..8], z3_addr[0..4], z3_addr[4..8]]
@@ -531,7 +531,7 @@ end
 #
 # Output:
 #
-# Last 6 memory addresses of 12 memory addresses which were provided during invokation, where resulting doubled
+# Last 6 memory addresses of 12 memory addresses which were provided during invocation, where resulting doubled
 # point is kept in similar form. For seeing X3, Y3, Z3 -coordinates of doubled point, one needs to read from
 # those 6 memory addresses.
 #
@@ -745,7 +745,7 @@ end
 # memory addresses holding x, y, z -coordinates of second input point & last 6 addresses are for storing 
 # resulting point ( addition of two input points ).
 #
-# Expected stack during invokation of this routine:
+# Expected stack during invocation of this routine:
 #
 #   [x1_addr[0..4], x1_addr[4..8], y1_addr[0..4], y1_addr[4..8], z1_addr[0..4], z1_addr[4..8], 
 #     x2_addr[0..4], x2_addr[4..8], y2_addr[0..4], y2_addr[4..8], z2_addr[0..4], z2_addr[4..8],
@@ -757,7 +757,7 @@ end
 #
 # Output:
 #
-# Last 6 memory addresses of 18 input memory addresses which were provided during invokation, where resulting elliptic curve
+# Last 6 memory addresses of 18 input memory addresses which were provided during invocation, where resulting elliptic curve
 # point is kept in similar form. For seeing X3, Y3, Z3 -coordinates of doubled point, one needs to read from
 # those 6 memory addresses.
 #
@@ -1182,4 +1182,16742 @@ export.point_addition.16
   pushw.local.15
   movup.4
   popw.mem          # write z3[4..8] to memory
+end
+
+# Given a 256 -bit scalar, in radix-2^32 representation ( such that it
+# takes 8 stack elements to represent whole scalar, where each limb is 
+# of 32 -bit width ), this routine multiplies group identity point 
+# ( 0, 1, 0 in projective coordinate system ) with given scalar, producing
+# another point on secp256k1 curve, which will also be presented in projective coordinate
+# system.
+#
+# Input:
+#
+# During invocation, this routine expects stack in following form
+#
+# [Sc0, Sc1, Sc2, Sc3, Sc4, Sc5, Sc6, Sc7, X_addr_0, X_addr_1, Y_addr_0, Y_addr_1, Z_addr_0, Z_addr_1]
+#
+# Sc{0..8}           -> 256 -bit scalar in radix-2^32 form | Sc0 is least significant limb & Sc7 is most significant limb
+# X_addr_0, X_addr_1 -> Resulting secp256k1 point's X -coordinate to be placed, in Montgomery form, in given addresses
+# Y_addr_0, Y_addr_1 -> Resulting secp256k1 point's Y -coordinate to be placed, in Montgomery form, in given addresses
+# Z_addr_1, Z_addr_1 -> Resulting secp256k1 point's Z -coordinate to be placed, in Montgomery form, in given addresses
+#
+# Output:
+#
+# At end of execution of this routine, stack should look like below
+#
+# [X_addr_0, X_addr_1, Y_addr_0, Y_addr_1, Z_addr_0, Z_addr_1]
+#
+# X_addr_0, X_addr_1 -> Resulting secp256k1 point's X -coordinate written, in Montgomery form, in given addresses
+# Y_addr_0, Y_addr_1 -> Resulting secp256k1 point's Y -coordinate written, in Montgomery form, in given addresses
+# Z_addr_0, Z_addr_1 -> Resulting secp256k1 point's Z -coordinate written, in Montgomery form, in given addresses
+#
+# One interested in resulting point, should read from provided address on stack.
+# 
+# This routine implements double-and-add algorithm, while following 
+# https://github.com/itzmeanjan/secp256k1/blob/d23ea7d/point.py#L174-L186 
+export.point_mul.18
+  # identity point of group (0, 1, 0) in projective coordinate
+  # see https://github.com/itzmeanjan/secp256k1/blob/d23ea7d/point.py#L40-L45
+  push.0.0.0.0
+  popw.local.0
+  push.0.0.0.0
+  popw.local.1 # init & cache res_X
+
+  push.0.0.1.977
+  popw.local.2
+  push.0.0.0.0
+  popw.local.3  # init & cache res_Y
+
+  push.0.0.0.0
+  popw.local.4
+  push.0.0.0.0
+  popw.local.5  # init & cache res_Z
+
+  # process bit 0 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+    push.589179219.700212955.3610652250.1216225431
+    popw.local.12
+    push.2575427139.3909656392.2543798464.872223388
+    popw.local.13
+
+    push.2382126429.522045005.2975770322.3554388962
+    popw.local.14
+    push.3477046559.3567616726.1891022234.2887369014
+    popw.local.15
+    
+    push.0.0.1.977
+    popw.local.16
+    push.0.0.0.0
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 1 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+    push.3437933890.2072183026.4256012599.474728642
+    popw.local.12
+    push.617223735.3276311816.1644336685.4191201175
+    popw.local.13
+
+    push.2826781693.3043178571.483526712.3875396767
+    popw.local.14
+    push.1440660280.524996660.3425160008.2758035882
+    popw.local.15
+
+    push.2688095969.1673463056.4082826636.2545792257
+    popw.local.16
+    push.579919648.1848170264.3884180958.2687252166
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 2 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+    push.2879351502.263705507.995471108.1088921762
+    popw.local.12
+    push.2832828146.2614124149.2170633936.2236521962
+    popw.local.13
+
+    push.4073438323.828812798.281675353.2210016624
+    popw.local.14
+    push.581575810.1361063577.1272615727.723804695
+    popw.local.15
+    
+    push.247196370.264991192.1311059568.2063719771
+    popw.local.16
+    push.1352383970.2724730208.2099681297.2989814637
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 3 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+    push.2068125131.1459464947.408359304.1594726639
+    popw.local.12
+    push.3848741185.1749606857.2031190394.2257649329
+    popw.local.13
+
+    push.3779299846.3281205734.1040561013.2394388049
+    popw.local.14
+    push.2749723167.857329376.1744556541.2858939227
+    popw.local.15
+    
+    push.2637562955.3679743535.2221345410.2840325697
+    popw.local.16
+    push.1658585184.2503743746.3205251131.4072748768
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 4 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+    push.1231228381.1813340316.821340817.722512669
+    popw.local.12
+    push.2081094477.3806951506.3254560673.721367143
+    popw.local.13
+
+    push.702108359.3709866115.197069253.2527134796
+    popw.local.14
+    push.2230544006.4199600988.2877849544.2612568121
+    popw.local.15
+    
+    push.1979715416.533757142.870983663.3321979243
+    popw.local.16
+    push.3510650449.435018679.1039046904.1998515401
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 5 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+    push.394522011.3501175395.1444831051.2712217010
+    popw.local.12
+    push.3275764810.1859615953.1889484915.3920395556
+    popw.local.13
+
+    push.3911776812.4104022181.1400047881.2096740742
+    popw.local.14
+    push.1099166461.2723866852.45181322.3558355291
+    popw.local.15
+    
+    push.3573223072.3532032629.752551711.4091923949
+    popw.local.16
+    push.3904370366.3487403656.3148714344.2420508884
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 6 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+    push.1026205514.557988677.1811735612.2526085733
+    popw.local.12
+    push.4256731487.1901518509.4257856434.1704010953
+    popw.local.13
+
+    push.2452202656.1756523026.2650272126.3072086044
+    popw.local.14
+    push.3313277609.3625027388.2823865272.1607317395
+    popw.local.15
+    
+    push.970167946.40178237.1094968387.73287484
+    popw.local.16
+    push.381366728.4201301544.1849045455.3628236831
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 7 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+    push.3457405453.2387867469.2030555195.2314634766
+    popw.local.12
+    push.633324806.2889210420.2971080174.4043757103
+    popw.local.13
+    
+    push.1582281044.3267081159.106787623.2219015849
+    popw.local.14
+    push.2523154591.3118632178.936853110.1450840467
+    popw.local.15
+    
+    push.1975931675.1402488620.1339206136.2915828072
+    popw.local.16
+    push.2281031812.2248683113.1719068146.1024688983
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 8 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+    push.3651363183.836005144.3738400743.1202071911
+    popw.local.12
+    push.3463148253.356534422.2789290949.2123776697
+    popw.local.13
+
+    push.1416992387.4248334506.2282654796.2958880515
+    popw.local.14
+    push.1682858830.972953161.3109216878.2729081681
+    popw.local.15
+    
+    push.1019743195.3715983474.2560515167.3916021123
+    popw.local.16
+    push.57736146.2003662631.1532849746.541811467
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 9 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+    push.1271163719.83748696.1243934934.1725045020
+    popw.local.12
+    push.1757200845.1579712529.3709155749.2490525753
+    popw.local.13
+    
+    push.163567449.2607846704.3022796594.258440691
+    popw.local.14
+    push.3569717.73386979.61235791.1396660245
+    popw.local.15
+    
+    push.1237597377.1596640373.1776096883.628236075
+    popw.local.16
+    push.3366549089.3619273576.2503475385.2238764922
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 10 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+    push.1427940723.7428921.1799368815.1571365520
+    popw.local.12
+    push.2085994872.3160934912.2377651848.3919221800
+    popw.local.13
+
+    push.447109814.1113377320.2767739398.2329310267
+    popw.local.14
+    push.2186442817.2178970503.2795624768.536421003
+    popw.local.15
+    
+    push.1571409508.3157339099.2485825496.1088857644
+    popw.local.16
+    push.3053614628.223221158.4248989966.3480032262
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 11 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+    push.2610818279.3536713782.3912065715.3176669737
+    popw.local.12
+    push.4075424326.2861468264.2826966158.1674842800
+    popw.local.13
+
+    push.3799491819.2512492662.1561581297.1582858834
+    popw.local.14
+    push.3268773358.1186072370.3532693070.1754135012
+    popw.local.15
+    
+    push.3312066550.1673939901.801066763.35873813
+    popw.local.16
+    push.1092243945.4177617868.2411532286.1464808813
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 12 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+    push.2920809398.4247331910.3148245799.620054778
+    popw.local.12
+    push.2717673753.2030337976.2469272834.1039085029
+    popw.local.13
+
+    push.113833265.53899627.2198645230.2433783572
+    popw.local.14
+    push.886461396.99491659.2951913132.3050734995
+    popw.local.15
+
+    push.3796496381.3873867960.4223744311.3807558599
+    popw.local.16
+    push.2453519330.2007784047.757956299.3351232194
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 13 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+    push.1036223050.951134442.706521218.3302693766
+    popw.local.12
+    push.3801555833.606845849.2896886910.209612018
+    popw.local.13
+
+    push.2137706936.1237760563.4027551371.959797812
+    popw.local.14
+    push.355318376.3348606533.26758351.110106597
+    popw.local.15
+
+    push.2950014256.1234570333.3441862140.1884477444
+    popw.local.16
+    push.1071817889.2535981847.620428557.2926284367
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 14 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+    push.3428312537.245232532.159612118.1418946393
+    popw.local.12
+    push.4118717561.2897385214.80459097.551686853
+    popw.local.13
+
+    push.3411429597.4034043018.47726183.1219468969
+    popw.local.14
+    push.1913316320.3313693373.1790647232.3862320970
+    popw.local.15
+
+    push.1080456887.2494968804.2088850801.3335786921
+    popw.local.16
+    push.117479910.4096465048.3748213334.1414641509
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 15 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+    push.617143603.3914299867.973684328.1024725525
+    popw.local.12
+    push.4131906068.3317883546.2714198383.2001977271
+    popw.local.13
+
+    push.3711094428.636908438.3875751458.1202552066
+    popw.local.14
+    push.1739612738.1344947376.1943259727.3984490149
+    popw.local.15
+
+    push.3363774533.3802573440.1406190571.1439164895
+    popw.local.16
+    push.1503048786.2253075200.1799563349.1602884526
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 16 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+    push.375341506.1929451238.2202716750.3251649326
+    popw.local.12
+    push.686489741.1349583.1129616092.580263380
+    popw.local.13
+
+    push.2596216462.3792018179.3285818282.756956372
+    popw.local.14
+    push.2713543322.2042185290.11499049.3239708649
+    popw.local.15
+
+    push.1982999048.864871296.1544240413.3816477355
+    popw.local.16
+    push.2933503355.1150771951.1010323564.4167348229
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 17 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+    push.1995151119.2875022893.4126873466.1465695309
+    popw.local.12
+    push.1176472168.204738826.1035950330.825829971
+    popw.local.13
+
+    push.962013080.3029188982.1759358514.2260129774
+    popw.local.14
+    push.1301017829.149015777.2073426303.2696251698
+    popw.local.15
+
+    push.2208886148.2594586529.1793088961.1024640302
+    popw.local.16
+    push.497957642.409392798.3397792514.121517090
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 18 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+    push.2888001427.725880224.3916942879.2971492725
+    popw.local.12
+    push.840954074.2449757058.1379796681.3174738595
+    popw.local.13
+
+    push.3293155039.1591403760.3205355140.3183698196
+    popw.local.14
+    push.3257309353.2970517532.1632831680.1663479127
+    popw.local.15
+
+    push.3490219988.2976614537.4225664693.115915521
+    popw.local.16
+    push.2881216904.2602803124.1931543326.3882383748
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 19 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+    push.9689525.3726457710.3737655682.334914726
+    popw.local.12
+    push.3876605360.3717017061.1792035884.3658180245
+    popw.local.13
+
+    push.149245088.1699366357.643757068.1988497688
+    popw.local.14
+    push.531073595.2716651538.445341804.376382049
+    popw.local.15
+
+    push.3064552040.1970812605.116048174.2935924752
+    popw.local.16
+    push.3782714730.3644631196.696007875.1704138562
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 20 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+    push.2439832784.2241875899.2018568169.352425916
+    popw.local.12
+    push.4226202437.3446455985.2921220771.2720721362
+    popw.local.13
+
+    push.3280520326.1791571865.3528296494.1537819910
+    popw.local.14
+    push.3416354503.3396109829.1820376351.2676305039
+    popw.local.15
+
+    push.2956912514.1820976906.2858508979.3798288869
+    popw.local.16
+    push.3427443063.2860962761.2699599650.3132555353
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 21 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+    push.2650406160.778134635.1314740119.784819757
+    popw.local.12
+    push.609348168.1469485514.3737623623.3981176228
+    popw.local.13
+
+    push.1725042470.1354922919.3698165144.2935842768
+    popw.local.14
+    push.672254616.2507033870.1329846737.2584119235
+    popw.local.15
+
+    push.672509300.246558793.1700474509.1043351151
+    popw.local.16
+    push.3364027452.3000806926.2213349683.2229151259
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 22 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+    push.1226687375.3732033419.115004589.2189803440
+    popw.local.12
+    push.3426423006.2009945648.1276908713.1016628304
+    popw.local.13
+
+    push.3482569193.4239763898.730303841.2872292874
+    popw.local.14
+    push.2936379902.171638723.2240304277.1414814578
+    popw.local.15
+
+    push.2825705970.894983440.92604647.1669533578
+    popw.local.16
+    push.2164444161.3254136612.31091988.2657278511
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 23 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+    push.1699129945.4088667013.2221645807.2263082900
+    popw.local.12
+    push.3602441774.1079003990.2719087255.2889008302
+    popw.local.13
+
+    push.2240713870.2366730935.1092671880.2600008203
+    popw.local.14
+    push.3624473750.2952716925.3626123566.3939227508
+    popw.local.15
+
+    push.783037882.4180090065.491508136.3319848281
+    popw.local.16
+    push.128933005.1843219761.3178323727.3041293948
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 24 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+    push.3595860352.359733990.1998376628.336093607
+    popw.local.12
+    push.1473277186.516789549.1236670775.3241023408
+    popw.local.13
+
+    push.2295255712.603738871.568714404.91523412
+    popw.local.14
+    push.266020797.1033180496.3919775067.1367605140
+    popw.local.15
+
+    push.2813675221.1303543082.904071087.593415411
+    popw.local.16
+    push.3148124861.38952013.3121562829.308148021
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 25 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+    push.3879371210.3081527059.1276965238.941234928
+    popw.local.12
+    push.1816515825.3248445909.1011391674.510317626
+    popw.local.13
+
+    push.3992782803.3093793053.2242553943.1562562381
+    popw.local.14
+    push.993766506.1627295219.1554902617.629484924
+    popw.local.15
+
+    push.1327291043.217154376.1729612892.1565252408
+    popw.local.16
+    push.2085282704.2941705734.1694467478.2630684944
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 26 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+    push.213605742.3333096384.3217865903.2426287159
+    popw.local.12
+    push.2470191657.1513487983.418351892.1119652998
+    popw.local.13
+
+    push.4180617317.2240474317.2237465588.504535800
+    popw.local.14
+    push.4188015931.1170021009.3217613595.2766194525
+    popw.local.15
+
+    push.2465044802.1876314770.1618583023.4201745150
+    popw.local.16
+    push.352153844.705577837.3808872676.1102893726
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 27 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+    push.2242801002.1887372273.2261272626.697912920
+    popw.local.12
+    push.2111777238.2607907222.1236593688.3793816203
+    popw.local.13
+
+    push.3399380590.1508547522.2142859827.1489169666
+    popw.local.14
+    push.2972896576.3146916577.1550249297.1954517472
+    popw.local.15
+
+    push.1095887046.4032951432.4174004315.2872058775
+    popw.local.16
+    push.3694830907.182787795.2738894540.3036843795
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 28 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+    push.2275040839.2829168165.3451153835.873194490
+    popw.local.12
+    push.3282419999.3093287994.2398937564.1992150115
+    popw.local.13
+
+    push.2736240994.204620363.4198863172.649949720
+    popw.local.14
+    push.3716024826.1233465505.1748859360.1474305547
+    popw.local.15
+
+    push.622684270.4179996509.247155377.2968359192
+    popw.local.16
+    push.3032668618.388189360.2716077947.95629646
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 29 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+    push.2660485347.280790875.789341098.1784021326
+    popw.local.12
+    push.2719014285.1389965106.567774045.2983137038
+    popw.local.13
+
+    push.3906121869.1890695637.1473469579.435252301
+    popw.local.14
+    push.605916942.2000138665.1814215102.3563723739
+    popw.local.15
+
+    push.3606314372.2559042446.2601336813.2405628422
+    popw.local.16
+    push.1746220919.3674660492.3263188964.3563175696
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 30 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+    push.2259138269.1269082684.3518089684.1408579258
+    popw.local.12
+    push.1077170122.2606831513.3331061849.4085012881
+    popw.local.13
+
+    push.3083051596.3455229223.3806463300.1067311995
+    popw.local.14
+    push.1054087177.3996065130.1153902543.1308735309
+    popw.local.15
+
+    push.3427855566.1602100217.508036311.3522943865
+    popw.local.16
+    push.2711196609.1792639260.3615873011.2733173106
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 31 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+    push.3036851339.1923498161.726990368.3678600041
+    popw.local.12
+    push.3425771566.128473889.2514510162.2442663658
+    popw.local.13
+
+    push.1295148995.3086274105.2998223779.3644828036
+    popw.local.14
+    push.325213743.3456678408.1460551922.225117710
+    popw.local.15
+
+    push.3365993235.3060310166.4166074507.1130079062
+    popw.local.16
+    push.1537097577.599500388.3188112682.4220919932
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # drop least significant limb of scalar
+  drop
+
+  # process bit 32 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+    push.4243021446.3930248375.2200770692.1999075395
+    popw.local.12
+    push.129624219.339457830.630538015.3385965042
+    popw.local.13
+
+    push.151326720.2244384650.2564835854.2688349067
+    popw.local.14
+    push.2683751654.671746037.2154085447.4171665086
+    popw.local.15
+
+    push.1973164475.3378236195.1258653325.1576379166
+    popw.local.16
+    push.3350578690.615105488.1907097206.2601362594
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 33 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+    push.3855932326.2341890268.2652231975.2356926667
+    popw.local.12
+    push.155733807.2116491013.4173803077.3196485543
+    popw.local.13
+
+    push.2323633777.1732115118.2807546675.750641548
+    popw.local.14
+    push.1202035494.287739238.571740796.3299463628
+    popw.local.15
+
+    push.2725203297.3303225153.3960676961.1547404409
+    popw.local.16
+    push.201781902.1879208033.366368531.414570348
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 34 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+    push.1163623805.1948397494.3700537393.849137747
+    popw.local.12
+    push.1283932233.3511547519.3538672689.11314807
+    popw.local.13
+
+    push.3902178200.899397401.1257173239.3980824920
+    popw.local.14
+    push.2729188126.1484193751.3310765108.2566167763
+    popw.local.15
+
+    push.2772346691.4292677869.2712131591.1034868192
+    popw.local.16
+    push.3447163093.240345314.298868343.2854454384
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 35 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+    push.490073796.82576743.3736828200.2440595515
+    popw.local.12
+    push.2900988164.93926751.2043608283.742260490
+    popw.local.13
+
+    push.374462255.1803158578.78057496.2160895405
+    popw.local.14
+    push.4246543775.1889068112.279926811.2028601906
+    popw.local.15
+
+    push.2166099010.193908061.2535080685.2680547871
+    popw.local.16
+    push.4240540981.1038306641.45839330.3995232274
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 36 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+    push.3739923889.2737757661.188520867.3134731939
+    popw.local.12
+    push.55085673.21751716.838984379.4037945171
+    popw.local.13
+
+    push.1971945276.1246327437.2318244733.392695281
+    popw.local.14
+    push.339227243.1041902608.1737746765.4234871778
+    popw.local.15
+
+    push.1223845880.3053283226.752051814.2177297027
+    popw.local.16
+    push.2640778917.132490793.363394045.1911428880
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 37 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+    push.732008708.1643820701.1273211715.2564901160
+    popw.local.12
+    push.2194757856.1271759781.3812828764.1428180415
+    popw.local.13
+
+    push.4070648574.1483168998.1858512776.1982122996
+    popw.local.14
+    push.723606342.1797479561.1778447394.695004162
+    popw.local.15
+
+    push.3169832676.3679023124.3388703121.123804462
+    popw.local.16
+    push.1377451392.1184542162.1605555025.2571230163
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 38 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+    push.2831523941.731204757.1174842552.849958179
+    popw.local.12
+    push.1505148098.1765012388.2178624482.91443771
+    popw.local.13
+
+    push.3967207165.3274186100.2836574355.503213154
+    popw.local.14
+    push.133427612.1750317322.3224897846.2169197977
+    popw.local.15
+
+    push.3025821908.3300532140.1772759211.764207700
+    popw.local.16
+    push.4190278158.3792837316.3788873439.820867659
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 39 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+    push.1391526698.1921207145.2742955422.1535773226
+    popw.local.12
+    push.1926013630.484251948.415199817.1631103609
+    popw.local.13
+
+    push.2461586542.2413395531.3976053596.1633706202
+    popw.local.14
+    push.4224874170.263556204.566886706.3338797609
+    popw.local.15
+
+    push.2188414816.1361704363.2222248250.3334053791
+    popw.local.16
+    push.1760021538.1246477538.4020221089.3103984320
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 40 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+    push.1819790809.2178166904.1239928156.1080120604
+    popw.local.12
+    push.2835085961.3716299352.237555353.1921923892
+    popw.local.13
+
+    push.1744963383.712453441.858381141.386431441
+    popw.local.14
+    push.975509937.643555121.2995576306.2581588267
+    popw.local.15
+
+    push.2299504905.3491302099.1827124646.3927673984
+    popw.local.16
+    push.3708375435.2356284909.871247942.462792261
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 41 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+    push.1454822092.3285728435.1378742502.2286879824
+    popw.local.12
+    push.3880482791.3490715278.3102890453.1121678620
+    popw.local.13
+
+    push.1070043390.4062955027.3408978548.2630134036
+    popw.local.14
+    push.4168957777.2777478178.2762588939.635394239
+    popw.local.15
+
+    push.799616421.598310406.3892303814.994983060
+    popw.local.16
+    push.2538873761.635116843.2411495690.1743653792
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 42 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+    push.4064955947.177800874.1883664398.1464320399
+    popw.local.12
+    push.206309447.3076885834.2680212206.2389366466
+    popw.local.13
+
+    push.1916228510.3794860938.87259858.2134340506
+    popw.local.14
+    push.543015909.627283566.3757523287.4037047826
+    popw.local.15
+
+    push.2595402405.1065652033.3754886750.2642017518
+    popw.local.16
+    push.1279883447.1293954212.4182039084.3246576295
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 43 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+    push.3919125906.4277306591.3238831685.2931784487
+    popw.local.12
+    push.3709863201.3778143269.2896263906.125746319
+    popw.local.13
+
+    push.810391584.2694572670.3103996657.1689488452
+    popw.local.14
+    push.1219396925.1173748168.2109412734.2759454143
+    popw.local.15
+
+    push.3012532821.866724528.1718901424.143820326
+    popw.local.16
+    push.1076151823.1869215212.3007531426.1975684790
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 44 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+    push.372104104.1584408275.2944612036.1338203853
+    popw.local.12
+    push.1690494135.638546508.6924999.2818818501
+    popw.local.13
+
+    push.1359135530.3000899183.2440466837.70908625
+    popw.local.14
+    push.3673851801.1115410695.3724980483.3822720403
+    popw.local.15
+
+    push.3963186459.1312373161.3916546418.614671223
+    popw.local.16
+    push.1090101602.1205871786.654432486.3225965430
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 45 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+    push.1455456054.754945335.676985571.2914491643
+    popw.local.12
+    push.1404132585.1151185088.767324933.2333244476
+    popw.local.13
+
+    push.1911268241.1480569170.3584517467.1841579576
+    popw.local.14
+    push.4036200447.1482344847.314907145.2151045431
+    popw.local.15
+
+    push.164251623.2078471405.3328639016.3001905155
+    popw.local.16
+    push.4064832735.3539470659.3958207760.3912356637
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 46 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+    push.3539050180.1781066486.43373161.28255872
+    popw.local.12
+    push.2399604296.182328218.1760516211.1873185083
+    popw.local.13
+
+    push.2124744571.2346921524.2086647707.3681689303
+    popw.local.14
+    push.450074572.1586083369.1057828945.3887057063
+    popw.local.15
+
+    push.1147770607.2748335909.2770239403.2976132499
+    popw.local.16
+    push.15108816.2267610399.3891474949.1238181223
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 47 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+    push.2537906632.3870987310.896931191.2693046389
+    popw.local.12
+    push.3679292966.3415736093.4256668678.1507188281
+    popw.local.13
+
+    push.1171302602.1894168152.3888981693.3119052069
+    popw.local.14
+    push.3098282248.2375464833.2753068900.3096449706
+    popw.local.15
+
+    push.2626062656.2969960579.795045560.1582482099
+    popw.local.16
+    push.209477031.3093707709.4202746756.3588225431
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 48 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+    push.3380407829.1964231819.2385143312.3590821817
+    popw.local.12
+    push.2355394185.2542849143.2322905173.3655294323
+    popw.local.13
+
+    push.865261756.628467235.3534700632.257948540
+    popw.local.14
+    push.388672815.2835872507.1352073514.2642551675
+    popw.local.15
+
+    push.1887798308.15330796.2072835962.3936084927
+    popw.local.16
+    push.3356353071.3616840600.1435566412.1090990745
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 49 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+    push.3027343521.290966086.2290059468.71556765
+    popw.local.12
+    push.1051337337.2228308901.788313012.1252691825
+    popw.local.13
+
+    push.2832582698.829271886.3153051282.1977879392
+    popw.local.14
+    push.2449763730.2394496880.738155419.4236696056
+    popw.local.15
+
+    push.2126009920.674356086.3726766216.3234863489
+    popw.local.16
+    push.3441957840.423571584.1961125286.3816809819
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 50 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+    push.3890280116.2092183917.3197959608.915862962
+    popw.local.12
+    push.3920810919.2647092939.4023234298.842016212
+    popw.local.13
+
+    push.1215912599.969643301.2262906276.3714363160
+    popw.local.14
+    push.474094330.2176442027.1386272556.758145133
+    popw.local.15
+
+    push.2832581714.1028213555.429877432.3895211061
+    popw.local.16
+    push.789267740.3629968881.1664142384.2098587670
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 51 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+    push.69881060.1033278612.3851756353.3366537903
+    popw.local.12
+    push.3056134945.4229139886.939290135.51360330
+    popw.local.13
+
+    push.2281282091.2471339352.3656431778.350550997
+    popw.local.14
+    push.2604912474.1817185359.1717463059.1951395870
+    popw.local.15
+
+    push.733833886.65213119.1910805953.3269891206
+    popw.local.16
+    push.615802927.3298463238.2997144325.3167811090
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 52 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+    push.1515776755.1670037745.3655800101.427888614
+    popw.local.12
+    push.4124258349.3715133632.3652150622.393900791
+    popw.local.13
+
+    push.876551824.4253025791.3370128350.1665076137
+    popw.local.14
+    push.2544117520.3785075401.785316795.3331397673
+    popw.local.15
+
+    push.173736952.1293986505.2136282037.2743837395
+    popw.local.16
+    push.4231928456.2296171318.3702809920.753297862
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 53 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+    push.4206239977.906494042.3036256728.469383574
+    popw.local.12
+    push.1579678045.2422919622.4285065105.4210704817
+    popw.local.13
+
+    push.15182657.551915631.2262568712.2017605335
+    popw.local.14
+    push.2542825453.918556626.2904917918.2336285602
+    popw.local.15
+
+    push.3780185729.913878096.122715666.3011542514
+    popw.local.16
+    push.3507786090.2609550599.2646253414.3308469527
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 54 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+    push.1264250571.2358786109.267699852.397371568
+    popw.local.12
+    push.3637624183.1559805603.1333100442.805741554
+    popw.local.13
+
+    push.1107823231.603239084.382051012.3624661940
+    popw.local.14
+    push.4026394363.3678135263.615594919.2550570861
+    popw.local.15
+
+    push.3127854526.3935157653.3975445554.3336576001
+    popw.local.16
+    push.4086335455.4174644744.2418015280.1854689529
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 55 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+    push.1337257023.2097803714.2186964309.69574727
+    popw.local.12
+    push.2405949463.612439938.1198226394.1290408248
+    popw.local.13
+
+    push.3520181822.1626008312.3556938481.3059913474
+    popw.local.14
+    push.4001034428.3315474656.4050303753.1689644323
+    popw.local.15
+
+    push.3052473835.3237345988.4223460066.4156192200
+    popw.local.16
+    push.394837729.1010332507.3156944571.2143230840
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 56 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+    push.3357835888.1199147507.852159997.1607276660
+    popw.local.12
+    push.1654467477.22959250.3011660105.1915149317
+    popw.local.13
+
+    push.2006818131.2226054321.3408831415.3550900475
+    popw.local.14
+    push.1590292234.3982591116.2110200815.2335589337
+    popw.local.15
+
+    push.1201925116.1539169354.935101213.497800014
+    popw.local.16
+    push.644457494.294749723.3842984229.3525701427
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 57 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+    push.474582552.145974266.481590094.3890661320
+    popw.local.12
+    push.2335629766.3192022847.1485647499.4114042288
+    popw.local.13
+
+    push.234978893.3854381809.3355693258.2862004276
+    popw.local.14
+    push.2410497750.2320046195.131304288.809022823
+    popw.local.15
+
+    push.1318738957.3769892322.3771464647.1936655279
+    popw.local.16
+    push.452052554.2695624202.2696142657.3325074837
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 58 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+    push.1595555664.560100810.3622299272.2184017943
+    popw.local.12
+    push.2460693588.2408572052.1048380281.210768845
+    popw.local.13
+
+    push.2008467572.2467008527.10799570.147667135
+    popw.local.14
+    push.2651068967.917918296.848198734.1676871213
+    popw.local.15
+
+    push.3586907049.3047188635.3344388971.1349055725
+    popw.local.16
+    push.3077906979.887309179.1155359897.3296386596
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 59 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+    push.366266016.2179268796.3962779698.2869202920
+    popw.local.12
+    push.1827635415.4205372956.634973838.2642160681
+    popw.local.13
+
+    push.1391447411.1514973159.3925070901.3714989833
+    popw.local.14
+    push.12096429.937681154.2410134947.3960205325
+    popw.local.15
+
+    push.4006816892.1268487531.920457673.484783460
+    popw.local.16
+    push.2942247545.986635644.1051121938.4283439008
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 60 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+    push.3850750957.2196229415.1401630839.3212445147
+    popw.local.12
+    push.2658904629.3454091496.2807737979.3100099893
+    popw.local.13
+
+    push.2732399273.1682772479.3396290441.2834527101
+    popw.local.14
+    push.1645294878.997276205.634264882.3408792906
+    popw.local.15
+
+    push.3061487694.4147612975.607809775.1089287651
+    popw.local.16
+    push.726014853.2559541446.674293275.701555975
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 61 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+    push.4186698633.1481211838.1371610537.2327704874
+    popw.local.12
+    push.933696081.2439244851.2615315712.913884404
+    popw.local.13
+
+    push.947249811.2187459943.3764781689.1174693308
+    popw.local.14
+    push.2213231104.2298001093.1842716286.1070815964
+    popw.local.15
+
+    push.1042186249.3945050167.2479429112.3552045223
+    popw.local.16
+    push.1766609812.2608568819.1370861363.3300260032
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 62 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+    push.2769350307.3068640479.1693301391.1534698952
+    popw.local.12
+    push.4176795803.3018042694.3874520595.1890360578
+    popw.local.13
+
+    push.2873721938.3342064369.342108151.3423621429
+    popw.local.14
+    push.83989058.2924946953.3482638132.48594429
+    popw.local.15
+
+    push.4092185250.851266439.171714579.3801417272
+    popw.local.16
+    push.2198053893.4122910262.3106106528.71799408
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 63 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+    push.3469890068.3946394267.511676447.3307380463
+    popw.local.12
+    push.3118428633.2959647369.3170637709.3372563825
+    popw.local.13
+
+    push.2054686107.245411910.3303524564.1966565957
+    popw.local.14
+    push.805807871.3470821989.2554015457.3847848274
+    popw.local.15
+
+    push.20693004.2502528377.2409187345.507577010
+    popw.local.16
+    push.3287381371.3514713235.3266414667.3832987379
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 64 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+    push.2105582013.4028571826.1398680223.929018991
+    popw.local.12
+    push.3051371635.2724935968.2360519577.3060172390
+    popw.local.13
+
+    push.1047474443.2470633620.2465897793.1686758339
+    popw.local.14
+    push.1294275752.4173584190.451385138.1139812898
+    popw.local.15
+
+    push.627807224.1897164151.3998369064.3248241325
+    popw.local.16
+    push.4286314443.881422584.1757972216.2844756714
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 65 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+    push.1750856401.854713088.3198409211.390915607
+    popw.local.12
+    push.2780136961.3904655003.1587424501.2652816032
+    popw.local.13
+
+    push.858162732.3912755742.2883780014.189242651
+    popw.local.14
+    push.2159015885.1044022165.2815084326.2219235391
+    popw.local.15
+
+    push.3219804275.4123662966.3658544901.3293455390
+    popw.local.16
+    push.3781102756.230988237.2945637147.2174577042
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 66 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+    push.2748119327.1620764752.2946535205.1489292690
+    popw.local.12
+    push.2548570297.4281812028.48393916.3998577308
+    popw.local.13
+
+    push.2969337763.1464112746.771926169.2799799103
+    popw.local.14
+    push.4002389836.3127936607.3603937497.3005053939
+    popw.local.15
+
+    push.3059474998.1121901657.1019618172.3863235390
+    popw.local.16
+    push.2195337937.783308501.2289061228.771833956
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 67 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+    push.3993810553.3730211394.1937555018.2236390468
+    popw.local.12
+    push.32975235.1901170796.2306495411.2596063487
+    popw.local.13
+
+    push.1226218693.3127214280.3888602397.854560206
+    popw.local.14
+    push.1445606176.2552927947.1547874355.466254502
+    popw.local.15
+
+    push.2989216687.1806064091.1180412485.3220192391
+    popw.local.16
+    push.2790742442.1647864019.3653429430.2226224714
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 68 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+    push.2102862854.4271041081.2471590568.1403471254
+    popw.local.12
+    push.614633720.3576486872.1822861865.1460303818
+    popw.local.13
+
+    push.1165237124.1570111634.1954462842.3022480631
+    popw.local.14
+    push.4280960021.1956846976.150088583.209108884
+    popw.local.15
+
+    push.220540804.3850811378.2558908538.2436681557
+    popw.local.16
+    push.440355473.1420892297.4060729519.104154129
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 69 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+    push.484431564.2490928341.1874515438.4041735840
+    popw.local.12
+    push.2488278332.489109384.2830315848.916058668
+    popw.local.13
+
+    push.4108900642.980052233.2348361273.2734504617
+    popw.local.14
+    push.2945370933.103726037.2975308047.1661158929
+    popw.local.15
+
+    push.3816305847.2405711196.2636355792.2128378950
+    popw.local.16
+    push.193950791.3758628274.1961876981.1054091348
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 70 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+    push.958053770.576130631.4155419959.1787957888
+    popw.local.12
+    push.115473950.822477978.1055291546.2879732828
+    popw.local.13
+
+    push.330852323.2165209260.4186224570.1059145280
+    popw.local.14
+    push.3403575861.3414551909.2845409721.2687779374
+    popw.local.15
+
+    push.4147811819.3812981490.2207581564.3186548262
+    popw.local.16
+    push.765489644.4204278716.420831615.686289746
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 71 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+    push.2407095031.1420560899.2675219549.2301384663
+    popw.local.12
+    push.1320712841.189371538.2462092567.415180916
+    popw.local.13
+
+    push.521573832.2073770098.159582541.1578764349
+    popw.local.14
+    push.790911321.1966535291.4197745626.3797023080
+    popw.local.15
+
+    push.2616179923.2620062287.847843478.3315509977
+    popw.local.16
+    push.346949059.3577731365.3661011466.2278886097
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 72 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+    push.1966465813.604647178.4196749756.789736869
+    popw.local.12
+    push.126499372.2858614875.1820339848.3533311886
+    popw.local.13
+
+    push.1808104770.2360198333.2482638774.3240947624
+    popw.local.14
+    push.3919016294.1315610693.2701541236.3111362429
+    popw.local.15
+
+    push.2709577220.2257654816.2708829808.3649193325
+    popw.local.16
+    push.2686476327.3170189344.2469236587.545799926
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 73 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+    push.3042011166.3980881876.2400451195.756850751
+    popw.local.12
+    push.1673473568.3246396932.3233126230.3694757456
+    popw.local.13
+
+    push.2422798041.605859356.2809127354.1885077772
+    popw.local.14
+    push.3451635145.3395420679.819372650.3183326785
+    popw.local.15
+
+    push.1001075623.1476446167.2116757194.657020538
+    popw.local.16
+    push.2021208394.4189291889.223928975.3084231900
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 74 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+    push.3889031629.3548347718.1528378206.1360271360
+    popw.local.12
+    push.684080650.3020149742.2575799977.4167697701
+    popw.local.13
+
+    push.951728142.863796929.806408025.1349686452
+    popw.local.14
+    push.1442184620.1745833116.3342210715.686503619
+    popw.local.15
+
+    push.1604304220.3213219414.2334978195.3552447160
+    popw.local.16
+    push.3765824723.3094155980.3563201915.2442217768
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 75 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+    push.4092388786.1074258664.4212587402.2823109854
+    popw.local.12
+    push.927854096.3419149860.1413812208.3997738346
+    popw.local.13
+
+    push.3081651707.1870075313.4214507112.2948708405
+    popw.local.14
+    push.1794423875.3659870744.1347323782.30742182
+    popw.local.15
+
+    push.3349180874.284708997.1030669352.852011505
+    popw.local.16
+    push.4025102189.3002044362.2610939516.968481390
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 76 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+    push.4083309621.1354160305.3345691164.3173403818
+    popw.local.12
+    push.275957873.3947229107.2154425801.1891283735
+    popw.local.13
+
+    push.2418964509.3263182117.3449144896.2671288163
+    popw.local.14
+    push.4022591230.2839066415.2079673701.530147430
+    popw.local.15
+
+    push.1620584395.2741203150.830642661.680216962
+    popw.local.16
+    push.57675626.3996181708.447113519.3325652353
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 77 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+    push.2624800978.1576084960.136666640.1429498917
+    popw.local.12
+    push.3977335559.438330674.3975547620.3361329560
+    popw.local.13
+
+    push.1841547412.3167977330.844458091.354057312
+    popw.local.14
+    push.1900090986.2881736842.377646265.755042002
+    popw.local.15
+
+    push.751714457.2921609162.2712683821.2673845263
+    popw.local.16
+    push.3796516846.457878672.3796078088.133390108
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 78 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+    push.2955562702.2067107445.2515787528.3157323974
+    popw.local.12
+    push.1296809448.1251514215.932999437.4048013732
+    popw.local.13
+
+    push.1157975516.2479831368.11565890.2480571873
+    popw.local.14
+    push.411715520.2447522776.2310497932.3781337653
+    popw.local.15
+
+    push.2213739025.2367077836.4120472051.60025773
+    popw.local.16
+    push.2170317792.1249770147.1610165525.10143291
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 79 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+    push.1873016892.2908160895.1761588077.4130817054
+    popw.local.12
+    push.3193794080.3956168732.2400363838.2611008937
+    popw.local.13
+
+    push.4225279449.3309431556.680901258.3062345760
+    popw.local.14
+    push.637579457.1426022496.3552004709.3521666672
+    popw.local.15
+
+    push.2968239279.2710169141.1002962628.2026748420
+    popw.local.16
+    push.3168557127.1599831230.1908704830.3582279181
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 80 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+    push.2147183140.2435889009.1124217110.692822312
+    popw.local.12
+    push.2571300373.2854085925.1206048166.434005132
+    popw.local.13
+
+    push.2437021524.2144223304.1558569048.2321955205
+    popw.local.14
+    push.542993901.1807479648.846889975.3208567005
+    popw.local.15
+
+    push.2536797638.3761558151.361836687.194462540
+    popw.local.16
+    push.45045079.3313636243.4065224498.2317706449
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 81 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+    push.965761796.909881260.423180520.1260309859
+    popw.local.12
+    push.3978895079.955654321.1597674889.2239392442
+    popw.local.13
+
+    push.471537044.4051323466.1851461799.1358762056
+    popw.local.14
+    push.3688744661.713843288.4211114079.4262002280
+    popw.local.15
+
+    push.2313100600.2724345757.1795155454.286184790
+    popw.local.16
+    push.3579288157.2293609170.2944134579.1851177124
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 82 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+    push.4256535327.971953462.2690202946.3464971495
+    popw.local.12
+    push.2792497975.3896150695.2601588359.2455467494
+    popw.local.13
+
+    push.2733669384.1808969764.2545608112.419424531
+    popw.local.14
+    push.200659473.2013938264.4029364271.1302990387
+    popw.local.15
+
+    push.4190172805.3941131213.3879978320.1209185419
+    popw.local.16
+    push.1710544862.3146657047.2110032199.367863398
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 83 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+    push.1043810021.167539280.297646337.3690202998
+    popw.local.12
+    push.1497500411.1425757150.1279677033.1216685214
+    popw.local.13
+
+    push.1490055384.2096715467.4118188432.2731821351
+    popw.local.14
+    push.1452441665.2147736672.3161960445.2412667335
+    popw.local.15
+
+    push.1283118447.724071994.454377685.2305006999
+    popw.local.16
+    push.3916810877.1299080966.4267126602.4134597698
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 84 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+    push.2930319825.4834939.4228156803.3141696362
+    popw.local.12
+    push.316863046.2372232826.538406169.3550510846
+    popw.local.13
+
+    push.1085851922.2152848749.3310053087.1878276787
+    popw.local.14
+    push.2044341764.1844924113.2633437963.1484033813
+    popw.local.15
+
+    push.4142097638.2354980066.2049983884.1728408872
+    popw.local.16
+    push.2226359467.1234800008.836810939.1007386657
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 85 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+    push.2238069073.1972041509.3614873861.3435216957
+    popw.local.12
+    push.3046696047.3996587108.4112183189.3505849815
+    popw.local.13
+
+    push.22096684.207965602.4210943564.3340997638
+    popw.local.14
+    push.146356977.899036247.280471051.1508419602
+    popw.local.15
+
+    push.1045002525.2930492521.2806553287.4230456169
+    popw.local.16
+    push.1767575569.4243592530.3870425872.4279724803
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 86 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+    push.45809781.769357890.2250396233.2343497395
+    popw.local.12
+    push.101061509.1886272056.3632026625.2035677118
+    popw.local.13
+
+    push.3892985643.1103735805.3157116484.2949779894
+    popw.local.14
+    push.4043651060.3495493696.1252064033.2559142819
+    popw.local.15
+
+    push.3381405462.568768815.1920956361.1188271888
+    popw.local.16
+    push.1636722311.1547049913.1160754888.794510130
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 87 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+    push.2054128079.2230972820.1127625440.3877806084
+    popw.local.12
+    push.1946758545.2978678576.1568487482.2887488155
+    popw.local.13
+
+    push.1292508732.2351765213.4022486584.1819066919
+    popw.local.14
+    push.1964184935.398013355.2989388614.815040508
+    popw.local.15
+
+    push.2011046877.707352156.2835874648.1958572988
+    popw.local.16
+    push.1152503915.4109489512.2705616261.150689496
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 88 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+    push.2364000695.2236109412.1337081733.3263008144
+    popw.local.12
+    push.3886166885.1656273194.1512802251.52274770
+    popw.local.13
+
+    push.2069884065.2871037537.4186082752.2270556422
+    popw.local.14
+    push.387208902.2980155850.2638774085.2147884509
+    popw.local.15
+
+    push.2830978373.3036320741.3540631672.1541874332
+    popw.local.16
+    push.2957471010.3524468751.680681556.3448300765
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 89 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+    push.767734023.4279048740.1157535992.2171654129
+    popw.local.12
+    push.963493471.68985541.1043941206.3626189511
+    popw.local.13
+
+    push.1845445059.82835290.3114620409.2927720915
+    popw.local.14
+    push.2519679746.4249792059.1555524640.3524697156
+    popw.local.15
+
+    push.2748829623.455193681.678110168.3855606563
+    popw.local.16
+    push.2420875917.3091767772.949655978.2440506923
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 90 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+    push.434197593.1436116311.2289836964.3641424224
+    popw.local.12
+    push.1157956470.3318692241.1442303333.43200738
+    popw.local.13
+
+    push.1160300146.1726410591.48937343.577065003
+    popw.local.14
+    push.4124851481.861020709.2520462156.1798162091
+    popw.local.15
+
+    push.2076799404.3271195648.3281460968.1433936315
+    popw.local.16
+    push.1834901373.2617710988.668444809.3960149915
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 91 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+    push.3453202519.1562435575.4285537762.2659185081
+    popw.local.12
+    push.2487884998.828076153.310132277.4117694234
+    popw.local.13
+
+    push.266201960.3537383044.3505185577.178631504
+    popw.local.14
+    push.2718144955.1650651555.2495057436.848817746
+    popw.local.15
+
+    push.494832992.1492556077.687268660.1023426763
+    popw.local.16
+    push.751466010.2811067554.949527296.2283947930
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 92 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+    push.2095404446.1325909471.3727571052.929126487
+    popw.local.12
+    push.821705374.3015236194.919943740.3722401695
+    popw.local.13
+
+    push.1152815177.3230722945.2581399890.4065463356
+    popw.local.14
+    push.2657196510.3644453791.2486409935.4039281400
+    popw.local.15
+
+    push.2339612881.3498123033.1366761769.3345003208
+    popw.local.16
+    push.151730902.1032282314.2922436459.1396993633
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 93 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+    push.4106358830.2661783832.3776584720.4129318781
+    popw.local.12
+    push.1990480316.3108426184.484457080.3469856670
+    popw.local.13
+
+    push.3881390677.2376572117.2628585139.771294546
+    popw.local.14
+    push.3898364616.610482295.1020747179.2757049303
+    popw.local.15
+
+    push.420949569.4247993496.3537190828.1313824226
+    popw.local.16
+    push.3343899360.3992358927.2866847288.2632213500
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 94 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+    push.2330202798.3793670437.1666342885.1131528605
+    popw.local.12
+    push.1767690935.150380127.1706638548.1772638692
+    popw.local.13
+
+    push.672412297.364455713.3151016307.1827031164
+    popw.local.14
+    push.3293037610.3985845895.3427308739.2661027154
+    popw.local.15
+
+    push.1868842473.471489517.3240431408.2117560880
+    popw.local.16
+    push.1084586120.702283184.3023486909.3570162450
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 95 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+    push.1517715605.509324179.1071779425.1403370981
+    popw.local.12
+    push.2065572673.98781838.235353061.3408575061
+    popw.local.13
+
+    push.290607056.2277295677.223961665.2214882506
+    popw.local.14
+    push.3423975001.1508641478.573623603.1974865253
+    popw.local.15
+
+    push.56821615.2081436588.1093641110.1777861755
+    popw.local.16
+    push.621790620.1936802240.1529138668.833231145
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 96 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+    push.3946426554.2808424719.4170712750.1543904120
+    popw.local.12
+    push.1983935828.3166429406.2672547269.1527713947
+    popw.local.13
+
+    push.3530652661.3557735053.1335483736.3474816117
+    popw.local.14
+    push.2482778285.2301672744.555633540.2349740190
+    popw.local.15
+
+    push.4111735944.102269432.467635238.1577869094
+    popw.local.16
+    push.999638617.1559089557.3770806934.3380534272
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 97 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+    push.1231664109.567958979.3727734293.2576619508
+    popw.local.12
+    push.3531792766.294827065.1721065140.3213216935
+    popw.local.13
+
+    push.4008534261.3921488869.3560147474.426442631
+    popw.local.14
+    push.4011558202.2993173694.1143099324.3905370773
+    popw.local.15
+
+    push.2544146444.3723219934.1779055491.4059355383
+    popw.local.16
+    push.1106650743.3907097879.3656920813.2999104053
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 98 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+    push.2215681696.1833117381.1052435029.3690170515
+    popw.local.12
+    push.297324649.2974671270.1457728066.1138090666
+    popw.local.13
+
+    push.641339019.3003232328.3827500595.25658289
+    popw.local.14
+    push.831563243.1555017039.562259675.705342321
+    popw.local.15
+
+    push.797713258.2183927562.2593236792.2160162012
+    popw.local.16
+    push.2809668745.4058896609.162130346.1119936282
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 99 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+    push.924747330.3934194257.1669859148.2436061424
+    popw.local.12
+    push.1111412495.845861911.128539704.2889741525
+    popw.local.13
+
+    push.3370732814.2437793624.3666376174.43863592
+    popw.local.14
+    push.3962023612.683497106.846149992.2303458042
+    popw.local.15
+
+    push.654318585.755323251.1176107628.1969179532
+    popw.local.16
+    push.3953355374.2219686724.2563637000.1606929534
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 100 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+    push.2201659057.2876929364.2065398710.2963265494
+    popw.local.12
+    push.2558794243.2635660306.2888006731.3211085519
+    popw.local.13
+
+    push.1861735910.3406293307.3082336510.4276027709
+    popw.local.14
+    push.1053455946.457787251.2252553626.1383432065
+    popw.local.15
+
+    push.631342944.2179504382.237867736.1445969530
+    popw.local.16
+    push.1275109758.885852953.2928852466.2936388372
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 101 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+    push.3611366268.1831994131.1719041647.1954708515
+    popw.local.12
+    push.3834948292.3280602991.1935020228.1650621784
+    popw.local.13
+
+    push.3569846179.679436820.281349768.3622374413
+    popw.local.14
+    push.288620013.3265472674.695666818.3889255464
+    popw.local.15
+
+    push.153990694.4014110973.1595414016.771844077
+    popw.local.16
+    push.2411874093.2682826721.2148243734.3143472347
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 102 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+    push.1466288375.908855089.3324924579.535293732
+    popw.local.12
+    push.4158117360.4027692640.3191217970.2629236568
+    popw.local.13
+
+    push.1500371005.2438658963.3421798001.3568821682
+    popw.local.14
+    push.3944598048.3526935232.1927944567.647231806
+    popw.local.15
+
+    push.3863390043.1626757698.3718359335.286443397
+    popw.local.16
+    push.3946196921.66840545.4253794039.1624065450
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 103 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+    push.1293697378.3746003679.4078024924.2261132022
+    popw.local.12
+    push.3177407800.1971593846.3430148714.1232847134
+    popw.local.13
+
+    push.1101723642.3570553653.2738459880.517023977
+    popw.local.14
+    push.923748974.749916797.1405785536.3348961098
+    popw.local.15
+
+    push.2704435240.1865777396.3198177515.1845975775
+    popw.local.16
+    push.3662249190.2283137214.1717416594.2138980524
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 104 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+    push.2257695780.3150774005.3970001509.4168348331
+    popw.local.12
+    push.2749955548.1442125546.4236912991.100200505
+    popw.local.13
+
+    push.2104758122.1266914505.687082796.2186987764
+    popw.local.14
+    push.1212688125.3562444091.2355173829.2489267689
+    popw.local.15
+
+    push.11268439.1229227033.1848823491.3049245032
+    popw.local.16
+    push.3249571275.2761391695.3028897536.1645505824
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 105 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+    push.3620512607.687083731.3852994955.2277125234
+    popw.local.12
+    push.2134278040.460748037.1514746734.2785187105
+    popw.local.13
+
+    push.2145126067.2053539985.813270778.377203065
+    popw.local.14
+    push.1216944309.1264231549.851526522.816789900
+    popw.local.15
+
+    push.1025218763.1299560201.4136975719.3097106974
+    popw.local.16
+    push.3099910167.2061596049.1531609397.157442371
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 106 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+    push.3003676891.127990804.748619701.2976996008
+    popw.local.12
+    push.4022809935.742879883.1502188510.1162142104
+    popw.local.13
+
+    push.2398274640.4173909105.3120283902.2576244133
+    popw.local.14
+    push.4155118099.2961520377.2637254360.3745765835
+    popw.local.15
+
+    push.3379731892.2891491678.2700850407.1579808355
+    popw.local.16
+    push.2108188033.1928983695.3942998603.2346131303
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 107 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+    push.792361920.300399448.3528400478.669124404
+    popw.local.12
+    push.3732826757.2276102682.1379325263.3526236643
+    popw.local.13
+
+    push.1321914552.2228030794.1514648476.668136951
+    popw.local.14
+    push.172774928.4063155861.1538650176.3299763994
+    popw.local.15
+
+    push.2662587842.1254455581.956335357.1548538666
+    popw.local.16
+    push.1795711342.2558634291.3079953412.4257929129
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 108 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+    push.2484169075.4220766875.1063432399.2900683076
+    popw.local.12
+    push.876509780.1085198534.1102146832.976721406
+    popw.local.13
+
+    push.4214490925.1906562462.1952197157.1599005289
+    popw.local.14
+    push.816218342.3528049166.1917761070.1501245270
+    popw.local.15
+
+    push.3635404226.2982070172.1443269872.2651068343
+    popw.local.16
+    push.2629773589.3749041910.3364031030.298369384
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 109 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+    push.3493933080.2766792520.1426639440.3277093746
+    popw.local.12
+    push.376017388.922017845.3585836087.3945654906
+    popw.local.13
+
+    push.3705085246.3045889630.3524321254.1519051765
+    popw.local.14
+    push.817380573.2501509175.1123613530.3648807890
+    popw.local.15
+
+    push.1923487622.241580526.2065847989.1560490530
+    popw.local.16
+    push.2311622675.3444708254.379693928.1465054857
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 110 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+    push.2488695529.3663340612.9878138.3784070159
+    popw.local.12
+    push.2674156217.1469372807.3351161501.3225878609
+    popw.local.13
+
+    push.1010530692.27495705.3733590032.65894539
+    popw.local.14
+    push.926218107.2885986491.3903999038.755000237
+    popw.local.15
+
+    push.4044202835.2978366651.2847348874.2617971131
+    popw.local.16
+    push.2427931454.3439410609.2632352345.1470675854
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 111 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+    push.2602052011.3107196463.955982553.2298050907
+    popw.local.12
+    push.2104423586.1178437464.3061453190.2781933201
+    popw.local.13
+
+    push.3051807764.633861420.1421982224.1438445533
+    popw.local.14
+    push.2359544288.1627206537.2692092431.373969561
+    popw.local.15
+
+    push.2898145007.3566884982.3505683229.3073794165
+    popw.local.16
+    push.686038994.931702740.147204559.1499823453
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 112 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+    push.120402000.2000063349.472439158.4003562864
+    popw.local.12
+    push.3413780705.1355210406.2383148278.3850206319
+    popw.local.13
+
+    push.2108266665.3112865854.1886498248.149081560
+    popw.local.14
+    push.27736301.4276340165.4084768652.3069971457
+    popw.local.15
+
+    push.1318572848.3513457001.1832881498.2708587029
+    popw.local.16
+    push.3463488704.1232505773.2007544314.4027405309
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 113 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+    push.1490889441.83398646.572879068.370871241
+    popw.local.12
+    push.362474641.1483757299.1482752995.4289161696
+    popw.local.13
+
+    push.1390154626.2657677842.4005475763.1948752428
+    popw.local.14
+    push.1669812522.195298905.2787149535.3114056813
+    popw.local.15
+
+    push.2388212050.419547213.3634128161.2569079333
+    popw.local.16
+    push.665353583.127533633.1733343691.2464992126
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 114 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+    push.1512327570.251195742.3672725365.3383771381
+    popw.local.12
+    push.1167315975.2781533644.3878733038.164402913
+    popw.local.13
+
+    push.1230225231.145414961.2860643194.2019099054
+    popw.local.14
+    push.1490820778.2524040702.2949045560.767323863
+    popw.local.15
+
+    push.3576771338.3293548109.3584476262.3266612892
+    popw.local.16
+    push.3854801163.784757327.3372162199.3147183541
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 115 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+    push.818765039.3092247215.590017123.3800644428
+    popw.local.12
+    push.3954370789.2853133304.3195712977.3596292424
+    popw.local.13
+
+    push.1736809266.3071816178.1369998928.1862080476
+    popw.local.14
+    push.3097072122.2252897532.2190861257.3980304007
+    popw.local.15
+
+    push.684636236.2852573017.3397940335.2943789561
+    popw.local.16
+    push.2972650254.848827651.3722641795.3902348624
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 116 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+    push.2532399528.680289515.2192312939.2841923315
+    popw.local.12
+    push.397116000.2218639206.2832690611.3617536122
+    popw.local.13
+
+    push.393537457.1346087180.3320063252.504978230
+    popw.local.14
+    push.2205536672.1952375961.3659938374.4281808523
+    popw.local.15
+
+    push.4092942795.1020537785.1314760526.2471424123
+    popw.local.16
+    push.1130219357.1877859925.3926463433.655282123
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 117 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+    push.3248842364.2812450433.3832086536.807052468
+    popw.local.12
+    push.3329408522.3747620573.1818430778.4002898834
+    popw.local.13
+
+    push.3373095435.2717381327.1644852652.1600431714
+    popw.local.14
+    push.1115806542.2950317302.2536969431.3057369897
+    popw.local.15
+
+    push.1629769019.3011898360.685922507.795138259
+    popw.local.16
+    push.3196531058.1243515018.1212118128.1471115477
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 118 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+    push.2333030850.1231655529.2534864055.4009649657
+    popw.local.12
+    push.2721338808.1744567649.2473559136.164195959
+    popw.local.13
+
+    push.4250521275.2361364460.1741518331.3877177070
+    popw.local.14
+    push.2340961958.194438317.2612985168.2648169280
+    popw.local.15
+
+    push.1605861937.1181659736.2081551892.3188897533
+    popw.local.16
+    push.2073564389.2689322569.3665402700.3464248338
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 119 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+    push.627313317.2324693906.838202588.1031242801
+    popw.local.12
+    push.247352440.3533768284.4074249497.3822515451
+    popw.local.13
+
+    push.3969186073.3749056353.1434534918.1739538012
+    popw.local.14
+    push.4154659109.3257067329.3752303332.2260462306
+    popw.local.15
+
+    push.3792415994.2730560668.3846001716.3385775570
+    popw.local.16
+    push.139247123.3077903373.3825563731.3705122380
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 120 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+    push.2091545405.1149321410.2586317549.86331127
+    popw.local.12
+    push.1804026901.2277639111.2523741659.2765154580
+    popw.local.13
+
+    push.1407401414.4126905107.2154671797.415548181
+    popw.local.14
+    push.2796857514.634550735.3491693139.1615513233
+    popw.local.15
+
+    push.2687949723.3328125129.1245445180.2378969076
+    popw.local.16
+    push.3271220055.2814967647.1133228357.3315355839
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 121 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+    push.1140001501.286141053.1712538385.2272347811
+    popw.local.12
+    push.69374038.2358553540.282302138.1488056790
+    popw.local.13
+
+    push.2072435197.2947835.1774211538.1275926818
+    popw.local.14
+    push.690226041.343580197.721098191.1047965908
+    popw.local.15
+
+    push.4164151184.1568903507.4057020202.3371225242
+    popw.local.16
+    push.2381289541.3075195764.1635941985.3310123332
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 122 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+    push.1726591552.2103482580.128723946.1664048234
+    popw.local.12
+    push.327901448.678003824.3685820211.3990855054
+    popw.local.13
+
+    push.2654470705.1709740202.371540969.2783616578
+    popw.local.14
+    push.4219313016.116411704.2226511914.1950195406
+    popw.local.15
+
+    push.825432954.3048967297.1526055797.687348508
+    popw.local.16
+    push.547411365.1875091201.3619462357.4238855041
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 123 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+    push.3108746976.2602061706.3020194108.3349542632
+    popw.local.12
+    push.1115573121.1914720819.3608288040.1836825161
+    popw.local.13
+
+    push.2445645117.224857084.4135583575.648792613
+    popw.local.14
+    push.3719755528.2012896675.3479094232.397353366
+    popw.local.15
+
+    push.3818598150.1454216861.2702483629.4212146368
+    popw.local.16
+    push.2098318341.2576522618.2441984467.3299524076
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 124 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+    push.87380209.4078895453.1639366402.91777993
+    popw.local.12
+    push.4036185603.2849598403.1651538958.3087474893
+    popw.local.13
+
+    push.2698799511.492065249.990858129.4131192616
+    popw.local.14
+    push.1142669719.3588887267.3556210923.820810977
+    popw.local.15
+
+    push.3203704518.257684398.1458934746.3968043265
+    popw.local.16
+    push.1047217830.1403044723.2236153565.2418722729
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 125 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+    push.1886596386.3920357886.2925563057.605688704
+    popw.local.12
+    push.3405612224.2129199950.2840531772.3183265187
+    popw.local.13
+
+    push.3888318136.4226168358.3420073953.679473937
+    popw.local.14
+    push.3992001302.2212804034.2533586678.271287025
+    popw.local.15
+
+    push.2127292439.1469394576.593557084.86692016
+    popw.local.16
+    push.4158708877.1241978907.1578478365.3404809454
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 126 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+    push.3061577248.1609110525.1318799245.582470858
+    popw.local.12
+    push.2867019135.601428751.514669271.52087952
+    popw.local.13
+
+    push.2753827489.4037102244.370123499.1248970440
+    popw.local.14
+    push.1276942563.3085068952.3831705189.742553915
+    popw.local.15
+
+    push.1398369724.3222974794.722154086.2489917060
+    popw.local.16
+    push.3406888139.1797554668.2261003503.1606664018
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 127 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+    push.2169819339.3466937103.2726892299.3717659155
+    popw.local.12
+    push.671004760.98858366.1319996870.1510381939
+    popw.local.13
+
+    push.1863818287.2341353042.2056583376.2262508885
+    popw.local.14
+    push.1289271936.1411810320.1612850052.604702419
+    popw.local.15
+
+    push.2903621440.65349278.1738331437.1559951867
+    popw.local.16
+    push.3901108667.2978150578.2140484758.2473618984
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 128 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+		push.792077805.3849054254.3341320233.2298120071
+		popw.local.12
+		push.2143033467.58622371.19193329.435664139
+		popw.local.13
+
+		push.3953373771.2194583657.2145614393.2722813744
+		popw.local.14
+		push.2241673337.116511288.2963824869.3183902225
+		popw.local.15
+
+		push.988674444.1510610333.995649495.846126732
+		popw.local.16
+		push.2895442476.2215110696.3024776878.2014863007
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 129 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+		push.3594205145.3478231389.1726614777.96238121
+		popw.local.12
+		push.3192232650.1975346810.4278687702.1040683771
+		popw.local.13
+
+		push.3736887147.607079206.2057184339.2688177366
+		popw.local.14
+		push.1441664212.2037172208.3858908676.334865804
+		popw.local.15
+
+		push.3476037993.3054816755.98465182.3952008231
+		popw.local.16
+		push.1927827307.2874280551.112860756.1698521712
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 130 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+		push.2091068109.1644290748.3003631132.121358825
+		popw.local.12
+		push.3312469602.2288063290.3837528054.199189819
+		popw.local.13
+
+		push.1908248248.2540102707.3781633004.56254144
+		popw.local.14
+		push.2489532327.770550708.2256565987.956757455
+		popw.local.15
+
+		push.4263111716.487763938.3110394647.554343052
+		popw.local.16
+		push.1933354832.1256628273.216683999.704075843
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 131 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+		push.371645915.2106918511.3162018088.1172841277
+		popw.local.12
+		push.2999380335.3697537888.531073802.2752901294
+		popw.local.13
+
+		push.1177355171.3360333508.1386735730.1955848377
+		popw.local.14
+		push.4289716226.3144947240.2389855506.2980504791
+		popw.local.15
+
+		push.700321620.3453076438.893514690.606089263
+		popw.local.16
+		push.1748776417.3010055774.2869800056.504899685
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 132 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+		push.3890731577.457292971.40712529.388389916
+		popw.local.12
+		push.1347529561.2802179893.2869951897.1536817341
+		popw.local.13
+
+		push.673494723.324283176.3849768216.2055261317
+		popw.local.14
+		push.552859389.3708339056.4050877314.1674809457
+		popw.local.15
+
+		push.472671125.1675340871.2177502784.1352462753
+		popw.local.16
+		push.824501553.3874455310.1112455047.1694170026
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 133 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+		push.3624950584.1533899097.2055253179.501738020
+		popw.local.12
+		push.1103191670.2249743073.1880978773.2095022150
+		popw.local.13
+
+		push.1442644806.1621608139.140707456.3161654250
+		popw.local.14
+		push.335950514.1135760495.1364328874.3947845556
+		popw.local.15
+
+		push.1841716269.490644074.3774337637.1617012474
+		popw.local.16
+		push.1641185695.3561105575.224771478.1529809627
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 134 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+		push.3455615407.544460235.4283235531.2808734768
+		popw.local.12
+		push.1049157668.4048606552.3688805333.258041226
+		popw.local.13
+
+		push.3419321238.900548646.3171847505.1632871479
+		popw.local.14
+		push.3804313617.2702658574.2023258108.1830829785
+		popw.local.15
+
+		push.984937033.1984873974.4263065565.370796384
+		popw.local.16
+		push.1580754376.193995505.1955262665.213724934
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 135 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+		push.1230271679.2564534995.1538379360.3840376258
+		popw.local.12
+		push.2377642332.3105748288.658941737.3848287119
+		popw.local.13
+
+		push.814557639.4075164095.151506914.3802561407
+		popw.local.14
+		push.2363080104.1665441107.4066025515.2109204365
+		popw.local.15
+
+		push.1496576875.336569921.825260533.94158768
+		popw.local.16
+		push.3194892716.865637286.2765349307.108164572
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 136 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+		push.1975555664.2360794075.189404495.3125024026
+		popw.local.12
+		push.2352684375.2580774530.761384299.21029020
+		popw.local.13
+
+		push.2200447727.2501315221.1860524645.1009959694
+		popw.local.14
+		push.3460243181.3844888820.3233286192.3274794079
+		popw.local.15
+
+		push.53950763.2668380391.671613586.1336192787
+		popw.local.16
+		push.450251810.928424712.2703391777.2563140621
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 137 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+		push.3041706134.3145900667.4111924089.886247057
+		popw.local.12
+		push.655473077.1614452765.722266091.1198923528
+		popw.local.13
+
+		push.1203116301.1913917406.2929270809.4071001299
+		popw.local.14
+		push.3200544417.625568451.2335576650.1015301833
+		popw.local.15
+
+		push.2689806454.130000742.3723042676.1354646945
+		popw.local.16
+		push.2553685397.3154728855.3667551962.4069506276
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 138 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+		push.3700076716.3216215371.1540149976.228142684
+		popw.local.12
+		push.397252675.999419436.3770044718.3897020825
+		popw.local.13
+
+		push.3533937348.3275929629.1852009830.869635757
+		popw.local.14
+		push.505264395.1050751288.3878113355.770538218
+		popw.local.15
+
+		push.2241787128.2139579637.3433130217.3211648711
+		popw.local.16
+		push.2517263576.4042753670.1491020741.2895083617
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 139 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+		push.3540255069.2266015559.2472946683.683280022
+		popw.local.12
+		push.3041398650.3038364316.612250299.612905714
+		popw.local.13
+
+		push.458966165.67657828.2041041920.1381601645
+		popw.local.14
+		push.934840656.2316700091.2457126757.4182809874
+		popw.local.15
+
+		push.1261403671.3135159688.1630687470.106067293
+		popw.local.16
+		push.936002814.1759351054.1143478402.2932513211
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 140 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+		push.3827793999.2078345016.871864670.2918539937
+		popw.local.12
+		push.922459716.3353852483.3059868674.1426832883
+		popw.local.13
+
+		push.1390383913.4199578999.2591082506.792771445
+		popw.local.14
+		push.2182460110.501852113.2657791012.3755043103
+		popw.local.15
+
+		push.4197499478.2904628123.4089742274.1442998264
+		popw.local.16
+		push.3228405253.2904260154.649894961.147244772
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 141 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+		push.1104882810.1812522460.1450059043.2006763478
+		popw.local.12
+		push.72048536.2030351545.536540664.2426277382
+		popw.local.13
+
+		push.4245740544.2831738898.40501219.2379008093
+		popw.local.14
+		push.1710140178.3785613242.1278628340.845164682
+		popw.local.15
+
+		push.16111364.2864130042.1477126338.2330202939
+		popw.local.16
+		push.3774381613.2697887140.2639241439.2419218767
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 142 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+		push.217610691.1132890332.3920496761.838200308
+		popw.local.12
+		push.4016434047.3893954152.3169458504.658396597
+		popw.local.13
+
+		push.3626716624.3185634155.2696696971.256186495
+		popw.local.14
+		push.555067810.2946559994.956354080.1845864765
+		popw.local.15
+
+		push.3690810651.936539915.3704890400.4089034327
+		popw.local.16
+		push.1854176042.3823042056.1279545337.805818429
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 143 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+		push.1183512439.2499553057.457416044.736048145
+		popw.local.12
+		push.2227444990.3150820916.3856603633.2494141677
+		popw.local.13
+
+		push.2269876683.2132563350.2504038369.1970936459
+		popw.local.14
+		push.3998515147.3021581729.2074126042.1557537567
+		popw.local.15
+
+		push.1507692569.1281600628.3223766956.155357635
+		popw.local.16
+		push.2311239571.1476631995.3332104220.2566855325
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 144 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+		push.1657470326.859950440.227049692.1917647286
+		popw.local.12
+		push.3245761527.2090793224.3803694223.2872224638
+		popw.local.13
+
+		push.1137018281.1249747418.2360432081.531659163
+		popw.local.14
+		push.2915115111.1834088157.837320649.582846028
+		popw.local.15
+
+		push.3432352577.2325131202.1089364199.1837417496
+		popw.local.16
+		push.1560337992.2136371016.2971344595.2622522778
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 145 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+		push.4207096107.844498082.193986483.2315585509
+		popw.local.12
+		push.1740791300.178466676.759101613.557586419
+		popw.local.13
+
+		push.4269089657.159249346.2417143298.604633941
+		popw.local.14
+		push.1173922859.2530273468.3447249784.1676422960
+		popw.local.15
+
+		push.3564617578.3829789775.2903744190.3473714053
+		popw.local.16
+		push.2300631554.2768029517.3132875763.3442053077
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 146 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+		push.2067901395.282245567.974220059.2605553653
+		popw.local.12
+		push.2774053275.950774412.879879733.2514940752
+		popw.local.13
+
+		push.1933440197.255711093.4224281033.2793556242
+		popw.local.14
+		push.973326635.2314976903.1005179394.284801849
+		popw.local.15
+
+		push.1423054495.3705134590.778485318.3688557279
+		popw.local.16
+		push.3669844999.2194479677.2360827768.2740703811
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 147 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+		push.1771778487.1702483630.2520017881.2097599392
+		popw.local.12
+		push.4205730677.667119327.1264760824.1869604868
+		popw.local.13
+
+		push.2565524488.1213645335.1318888216.2320489479
+		popw.local.14
+		push.1574293651.3454274422.3072976757.3597577590
+		popw.local.15
+
+		push.130779285.1492730115.2024272269.3453860775
+		popw.local.16
+		push.4191400341.1202587609.947879290.2854050194
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 148 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+		push.2064218735.3605377863.176942435.710936868
+		popw.local.12
+		push.2563520090.1347964491.1614423994.1739478643
+		popw.local.13
+
+		push.1197206032.2513745684.3245150371.1718269768
+		popw.local.14
+		push.53387044.317289168.3379380930.2980798659
+		popw.local.15
+
+		push.3157582275.2937611601.4276275493.1179879697
+		popw.local.16
+		push.3549350156.23411.1804247676.2301467555
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 149 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+		push.4025725898.1821789688.2396070653.4255302914
+		popw.local.12
+		push.1930928871.4255666404.2691552099.386455188
+		popw.local.13
+
+		push.460012929.1774535072.2114302751.2459109992
+		popw.local.14
+		push.1516208887.3241099520.1470010580.2955634286
+		popw.local.15
+
+		push.2790064090.3566046262.1680493640.3773589374
+		popw.local.16
+		push.2222357263.86162422.3543097117.1668404676
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 150 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+		push.1622944700.2357953766.729038944.1466694589
+		popw.local.12
+		push.579443649.204398433.2134757350.3542208621
+		popw.local.13
+
+		push.1402673100.1665145998.2418303385.4102225222
+		popw.local.14
+		push.7922123.2772545079.2003728222.3187977222
+		popw.local.15
+
+		push.4016507243.292370172.1888368110.862290367
+		popw.local.16
+		push.1808123580.3848144968.637967900.3009040128
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 151 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+		push.1643073482.2839435546.3019355970.188646773
+		popw.local.12
+		push.2580400090.4004401094.791246640.3578852948
+		popw.local.13
+
+		push.2141131164.2390500499.4259384733.2509011624
+		popw.local.14
+		push.3964168896.3789324374.65590157.156407385
+		popw.local.15
+
+		push.1832846760.1874310065.4112770673.71782914
+		popw.local.16
+		push.1319304454.328624789.2915081368.2491623375
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 152 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+		push.2546084155.3608554673.2405328688.3971361475
+		popw.local.12
+		push.3000682049.2858438453.1944465110.1431805862
+		popw.local.13
+
+		push.2732390218.2694344811.479332761.1411019904
+		popw.local.14
+		push.381471743.1652457212.4054018291.1898221274
+		popw.local.15
+
+		push.2183317250.1176990790.985758808.3854368708
+		popw.local.16
+		push.991231597.940860021.3801054757.3892051235
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 153 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+		push.1414633309.2571998273.3448729772.2561368912
+		popw.local.12
+		push.2707033048.2856148546.1725453397.2459401074
+		popw.local.13
+
+		push.3724198387.970705117.2098511613.3553089727
+		popw.local.14
+		push.2235034310.3630461779.1062669979.348510416
+		popw.local.15
+
+		push.2238199733.973539500.1572884162.2220314349
+		popw.local.16
+		push.842536906.469178569.1234219247.154499569
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 154 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+		push.1989752537.2626584356.1453296241.3300145207
+		popw.local.12
+		push.1683716820.3717024419.2285627997.4269125309
+		popw.local.13
+
+		push.3475575137.3796718024.66691442.1778027685
+		popw.local.14
+		push.3747196075.2186333639.1195494790.3731492381
+		popw.local.15
+
+		push.948327796.3676807926.3017390535.956433714
+		popw.local.16
+		push.1134162676.1562574376.3190511781.1420389826
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 155 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+		push.3089564150.3751207063.1282659451.3150553535
+		popw.local.12
+		push.564534705.3590651950.648080079.119337249
+		popw.local.13
+
+		push.2957661592.1768446826.2073159635.273160305
+		popw.local.14
+		push.540420806.1085928370.3472400130.1311479721
+		popw.local.15
+
+		push.2773322276.4210519381.4031158241.1316466316
+		popw.local.16
+		push.969597978.4197815787.2549204570.2390660699
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 156 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+		push.724823211.1696035521.1405982363.1503913523
+		popw.local.12
+		push.1641588201.1997556269.3052383629.1417490188
+		popw.local.13
+
+		push.1907231098.3362427654.1388992075.3781051589
+		popw.local.14
+		push.1903256371.2986175708.2949448216.4191546126
+		popw.local.15
+
+		push.808987913.3741968100.1045223618.1007299885
+		popw.local.16
+		push.2243633778.1526749261.3382364361.4066010598
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 157 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+		push.1198933407.2333643671.1240413.4072937665
+		popw.local.12
+		push.2663798275.3749853823.4123467059.345469238
+		popw.local.13
+
+		push.2804006955.1477697650.3981985868.3585860031
+		popw.local.14
+		push.3356106588.747404536.2184439659.3126202264
+		popw.local.15
+
+		push.3620985093.3509816817.3835351948.569581106
+		popw.local.16
+		push.1413788852.3748821879.2803331137.2495568737
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 158 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+		push.4269063248.3405512655.3016657240.2334632081
+		popw.local.12
+		push.1020796908.3273942413.1102842203.3813857876
+		popw.local.13
+
+		push.942482521.2123259483.898690763.4248309983
+		popw.local.14
+		push.1443400350.2184489318.1358879432.884196765
+		popw.local.15
+
+		push.933616770.4280554689.1018855947.1685953442
+		popw.local.16
+		push.2475964213.1486635410.3696176718.399194739
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 159 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+		push.552117193.1382740006.3895393951.1754314637
+		popw.local.12
+		push.1213778273.1436093414.34586292.3970718009
+		popw.local.13
+
+		push.1483184174.1868917149.2696141113.4046771950
+		popw.local.14
+		push.1086151138.1666520193.4195531705.1681900111
+		popw.local.15
+
+		push.577715395.3484327043.1163258242.2312722803
+		popw.local.16
+		push.3175450897.354570379.1102206875.1183272488
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 160 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+		push.1315823684.2794440437.1791126631.1134914047
+		popw.local.12
+		push.3739359822.874169731.2210747310.2852570808
+		popw.local.13
+
+		push.965999638.3844643327.2205994417.3373054360
+		popw.local.14
+		push.2350525150.621595852.156133309.2217548599
+		popw.local.15
+
+		push.2132793259.1797137216.3995667102.3967195197
+		popw.local.16
+		push.63117983.1187521712.2688609646.909566848
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 161 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+		push.3399265666.3623759520.2842470626.767441890
+		popw.local.12
+		push.1906217998.229857777.880446017.4235385205
+		popw.local.13
+
+		push.2892217978.2244453941.1805654601.2085415298
+		popw.local.14
+		push.698220954.2320123396.3767549439.3133813121
+		popw.local.15
+
+		push.511154139.1639256147.3513875857.1404364344
+		popw.local.16
+		push.806597099.7405547.4096525630.1884454932
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 162 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+		push.1378492106.2513425548.2045927279.3609631116
+		popw.local.12
+		push.3623148261.3141457921.1110942374.1809199798
+		popw.local.13
+
+		push.2995245769.2542725840.2964742948.1219200045
+		popw.local.14
+		push.1431848240.1480682263.933038027.500897650
+		popw.local.15
+
+		push.2176753313.1653542029.1543323461.2096306219
+		popw.local.16
+		push.2626421069.3013923005.3999983932.3727120669
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 163 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+		push.1298864518.4123512033.2051052216.1319389080
+		popw.local.12
+		push.3427738026.2163458914.2534286542.670047644
+		popw.local.13
+
+		push.1541595784.1467679288.4093173307.1502371903
+		popw.local.14
+		push.4125514701.283189010.2302495078.3481125069
+		popw.local.15
+
+		push.540457411.244968516.2079562759.162079306
+		popw.local.16
+		push.564503032.3093958349.1701436582.508470974
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 164 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+		push.1849060659.1284433717.2438538713.1736679491
+		popw.local.12
+		push.3989935567.3764254773.1428435245.598748263
+		popw.local.13
+
+		push.4115073706.2043856024.3071963505.440821427
+		popw.local.14
+		push.2085293697.1556521465.1670665409.2946548387
+		popw.local.15
+
+		push.2480320038.1208633101.182733897.2462027731
+		popw.local.16
+		push.4245247200.1311108936.2234579946.701605203
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 165 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+		push.2226718651.1174910472.1549577981.2899960270
+		popw.local.12
+		push.2214697074.4042098324.1875823367.954527288
+		popw.local.13
+
+		push.2064128177.3765538787.3285321210.1088008546
+		popw.local.14
+		push.309065148.1211888862.2287834734.2226190713
+		popw.local.15
+
+		push.3095685296.2382988635.3764891871.2036557529
+		popw.local.16
+		push.3214402739.2260872620.428885723.1320317911
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 166 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+		push.1709796860.3123488407.1268848768.2788334963
+		popw.local.12
+		push.1550661127.4113136477.4129107867.3450727525
+		popw.local.13
+
+		push.964688560.2478710384.184439768.3049668021
+		popw.local.14
+		push.1786448347.3123252037.4142919317.2000593835
+		popw.local.15
+
+		push.135179130.405322578.123384097.3833149481
+		popw.local.16
+		push.817944084.2922799794.1965720193.3068454134
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 167 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+		push.3180824165.2796858421.390155025.3252239109
+		popw.local.12
+		push.3755274059.1093758680.2832778966.2707567368
+		popw.local.13
+
+		push.1882284178.2274240076.61356569.97975973
+		popw.local.14
+		push.1563901362.2462886146.1251013731.1913849350
+		popw.local.15
+
+		push.4163355696.2553824423.632882177.1460416309
+		popw.local.16
+		push.1887329780.3522056787.2697588105.2677053289
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 168 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+		push.2761635638.2501425637.1421115322.540961415
+		popw.local.12
+		push.2416868770.842982332.1897801874.336353303
+		popw.local.13
+
+		push.845017214.1525614536.2478474835.2882047916
+		popw.local.14
+		push.1605216604.3487841655.3672032306.1217923547
+		popw.local.15
+
+		push.248035252.1956053934.1482204716.202099685
+		popw.local.16
+		push.1180270768.4070856243.1019180653.1108013791
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 169 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+		push.2610024954.171445359.4131381121.2223600951
+		popw.local.12
+		push.633969611.652656590.3025194991.253256001
+		popw.local.13
+
+		push.3649368726.1189344453.1705257487.2248818897
+		popw.local.14
+		push.3135123011.791478914.3156881862.306857657
+		popw.local.15
+
+		push.2180509229.2331008552.1029181051.49527350
+		popw.local.16
+		push.130735258.4060142944.1883010749.3160979394
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 170 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+		push.3578703254.3489860685.3809209770.1491810965
+		popw.local.12
+		push.3516169663.1271621923.2492513716.832418194
+		popw.local.13
+
+		push.3513661688.2021908680.304851617.4004094745
+		popw.local.14
+		push.2358681903.3871874951.4039825782.1137970111
+		popw.local.15
+
+		push.2741865528.3612459500.2537950457.2064564966
+		popw.local.16
+		push.2410874676.4043533792.1401390958.574408037
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 171 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+		push.3945153907.42688053.1599561854.2104929750
+		popw.local.12
+		push.95781997.4160360877.1090830158.1089602625
+		popw.local.13
+
+		push.2227672957.1004174379.3282150805.2691638537
+		popw.local.14
+		push.3917916306.2676548023.1305427787.2591560018
+		popw.local.15
+
+		push.3282184936.709775722.1526202438.3115170250
+		popw.local.16
+		push.2448987925.3275442066.1827409637.1674290320
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 172 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+		push.2237692178.3745562400.1904627517.3550879148
+		popw.local.12
+		push.3133691620.2462573880.2523426974.1654057057
+		popw.local.13
+
+		push.4241419297.3200751746.1702646116.2102320562
+		popw.local.14
+		push.2635902487.4271308573.1055526533.2750425995
+		popw.local.15
+
+		push.1326606968.2762804126.2747960092.4198618395
+		popw.local.16
+		push.238305217.1585442315.415298656.2905300146
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 173 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+		push.949467963.3654938676.2261950315.3621369856
+		popw.local.12
+		push.3993795767.1140295863.1936656814.1879108671
+		popw.local.13
+
+		push.3923681703.3783117492.1987867447.2124922347
+		popw.local.14
+		push.3963400091.2804451292.291357235.1347715243
+		popw.local.15
+
+		push.2601190321.1827087234.3763719913.3386779367
+		popw.local.16
+		push.3496511508.3240977.2052137645.1216365629
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 174 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+		push.347758131.2042307323.3364394997.2868857603
+		popw.local.12
+		push.1644097626.1470481828.3583775446.1060206785
+		popw.local.13
+
+		push.3255039374.3683362559.2219244949.148516568
+		popw.local.14
+		push.4047902427.1627383396.2301165011.1662316042
+		popw.local.15
+
+		push.3576642928.1673782302.3520797747.1885172576
+		popw.local.16
+		push.1362574001.2459510299.2777836709.4172165059
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 175 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+		push.3760457677.3744585930.2980919435.3638455722
+		popw.local.12
+		push.4123952205.251004692.3428292584.737118408
+		popw.local.13
+
+		push.191957737.2156796861.2457730292.1459335571
+		popw.local.14
+		push.4126630232.2439936881.819384768.2755116977
+		popw.local.15
+
+		push.2855826582.1323044414.3685599927.2021328076
+		popw.local.16
+		push.1026626164.698929808.3550246064.1187279806
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 176 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+		push.3679361876.1786587470.3330253884.1614258177
+		popw.local.12
+		push.1171379260.195320030.4050995933.942701412
+		popw.local.13
+
+		push.2156930754.1454279754.2238516829.1477840259
+		popw.local.14
+		push.352574919.3948202420.92925261.77813632
+		popw.local.15
+
+		push.3585788122.1819876757.2092004150.677895715
+		popw.local.16
+		push.1064878524.3905951391.2860639113.271252031
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 177 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+		push.3260747829.505961830.964948814.1606163850
+		popw.local.12
+		push.1458468889.3623226609.4038826991.3454171911
+		popw.local.13
+
+		push.4208234474.2802769324.690338428.3857503376
+		popw.local.14
+		push.4273124973.4009083844.139471253.2324698278
+		popw.local.15
+
+		push.3783182816.2675786977.3362052445.3724241470
+		popw.local.16
+		push.3695043063.3720015305.832763561.404082991
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 178 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+		push.1458388276.3256615166.166790556.2414061174
+		popw.local.12
+		push.846307017.1042860320.55717745.1282736061
+		popw.local.13
+
+		push.2167892138.3364694040.896190836.1213716323
+		popw.local.14
+		push.3303669867.3334998183.3127375531.763491688
+		popw.local.15
+
+		push.2866583962.2942663523.3050012457.630862930
+		popw.local.16
+		push.1661239275.3726187141.1638625686.227416827
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 179 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+		push.536842472.3564942660.1625988705.3824486601
+		popw.local.12
+		push.271783886.669166123.1487292449.1525245500
+		popw.local.13
+
+		push.1283860101.1502550714.455316307.3455732793
+		popw.local.14
+		push.2135040285.3571659439.3746348982.1679301970
+		popw.local.15
+
+		push.375966150.4187197681.2316199144.4122857260
+		popw.local.16
+		push.3575442036.2293595514.872338064.660397928
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 180 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+		push.2620134969.158971595.1393095156.1886838778
+		popw.local.12
+		push.2618869420.4023564048.1136765549.2021684249
+		popw.local.13
+
+		push.2511445427.683260061.523237886.368897638
+		popw.local.14
+		push.3327815613.56105643.1560171414.2188376037
+		popw.local.15
+
+		push.4189016784.1386868487.2015805813.3093829931
+		popw.local.16
+		push.2489227148.2417209724.2527997172.2244008580
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 181 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+		push.2758940507.3572260954.1736307102.1446510083
+		popw.local.12
+		push.1350799915.4123118312.2235979054.637155520
+		popw.local.13
+
+		push.1488642755.1803035816.884628605.1607593277
+		popw.local.14
+		push.2988512250.1558815963.3977787377.558855054
+		popw.local.15
+
+		push.1855517426.1117565088.3496303175.3622632311
+		popw.local.16
+		push.2460265381.4144472402.1999209392.47540040
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 182 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+		push.357397228.2407199632.1152780213.526524990
+		popw.local.12
+		push.3531851127.127763693.3035754922.2010347478
+		popw.local.13
+
+		push.380174645.3572415106.3881554764.4086155489
+		popw.local.14
+		push.106692475.494865399.2350813721.2191490510
+		popw.local.15
+
+		push.902765376.1482768963.70200561.718195788
+		popw.local.16
+		push.2325780958.1404316001.1024012863.1753029313
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 183 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+		push.4120163719.208444573.3273066836.2396310581
+		popw.local.12
+		push.1991575676.3851010087.4252846179.749245841
+		popw.local.13
+
+		push.3239328829.390770388.3076568543.1159901950
+		popw.local.14
+		push.2422932427.1243854876.859155462.1114290235
+		popw.local.15
+
+		push.862089947.519164438.2477992711.1268333762
+		popw.local.16
+		push.2648568157.802486206.1844235730.1127006053
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 184 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+		push.2600871450.3694150655.2251812839.113681128
+		popw.local.12
+		push.1700774722.4049959931.1055892457.3152238957
+		popw.local.13
+
+		push.1306922071.92940236.1765659600.4246594444
+		popw.local.14
+		push.3187924916.786830645.3231598680.3698529334
+		popw.local.15
+
+		push.648011985.2894234737.829511402.3797767974
+		popw.local.16
+		push.762542982.1693412854.398831332.997153191
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 185 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+		push.2732300811.1034747874.1952067483.3840689472
+		popw.local.12
+		push.526779139.2360844429.1085958826.2079343349
+		popw.local.13
+
+		push.3379919812.902031332.4127234423.1068203296
+		popw.local.14
+		push.3936080342.4150463149.3104492125.859234643
+		popw.local.15
+
+		push.3405557562.4225516526.3753452237.3488373140
+		popw.local.16
+		push.3319977298.1001761551.954397555.697850973
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 186 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+		push.3466081709.2155866485.423378708.3584536917
+		popw.local.12
+		push.1100405854.1312685569.61228804.3777838166
+		popw.local.13
+
+		push.210886216.3516169055.1859673874.894345970
+		popw.local.14
+		push.1237506035.4265919547.2089424609.3941932843
+		popw.local.15
+
+		push.2966833882.2351683939.1111934998.3100990287
+		popw.local.16
+		push.686162940.2086455682.2696457207.3676608649
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 187 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+		push.3304653604.1672792160.3324660356.1546633361
+		popw.local.12
+		push.1368384392.2327397257.72244593.1700814592
+		popw.local.13
+
+		push.3174822453.991180681.2705927234.377884417
+		popw.local.14
+		push.1158199531.3799617076.3853631473.833763321
+		popw.local.15
+
+		push.920329661.1082979201.998203728.3163783243
+		popw.local.16
+		push.443574089.2513612014.451559263.1811553988
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 188 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+		push.3753579883.2697680033.1367299585.2733294006
+		popw.local.12
+		push.3995448026.1072833636.1591548871.178613484
+		popw.local.13
+
+		push.503468350.2737252546.1031061364.1487746185
+		popw.local.14
+		push.3918087802.5294091.1339402345.2713697084
+		popw.local.15
+
+		push.1047066571.3292039577.4112704125.3013510086
+		popw.local.16
+		push.3234620089.3791026977.3538719421.169647033
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 189 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+		push.1172824150.2938808110.836617547.2098338587
+		popw.local.12
+		push.121112172.394822179.1382539451.255974591
+		popw.local.13
+
+		push.2843153173.2952610112.1932654674.3072390569
+		popw.local.14
+		push.656256402.1350580952.3960259101.488937829
+		popw.local.15
+
+		push.2342702666.2735168124.2320052430.844345549
+		popw.local.16
+		push.709389494.1709536089.2626782382.2343598486
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 190 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+		push.3935157946.1580307507.2250644174.2111463341
+		popw.local.12
+		push.784744739.498279707.367361455.316954808
+		popw.local.13
+
+		push.3916925008.1869955556.3866251702.1520426086
+		popw.local.14
+		push.1107933401.1375155703.1786752218.3981357010
+		popw.local.15
+
+		push.3385810362.3330711099.4068064403.1184469162
+		popw.local.16
+		push.2686161319.689314721.2166867550.1840971114
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 191 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+		push.160317760.970965281.617450999.4247894070
+		popw.local.12
+		push.4232136298.500599656.1980254106.1401512210
+		popw.local.13
+
+		push.2408713695.1608465013.2938032522.3222242592
+		popw.local.14
+		push.2636379163.1876157952.91472819.1364457688
+		popw.local.15
+
+		push.270375959.87328024.2968835233.2210678258
+		popw.local.16
+		push.2937671341.1534065227.925069856.930630357
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 192 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+		push.2872698197.1090373982.4141452066.1105078949
+		popw.local.12
+		push.4116855273.3414195230.1707157191.2140451481
+		popw.local.13
+
+		push.3105661636.4165081031.2402686886.2704817268
+		popw.local.14
+		push.2009691811.2882546771.4134283004.2391646836
+		popw.local.15
+
+		push.2888603813.3943606262.3079889941.1050687071
+		popw.local.16
+		push.4119812715.2999452556.180875859.1322938549
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 193 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+		push.1213933469.1414913109.3762377620.2389861385
+		popw.local.12
+		push.1513135599.2589219924.2808858786.1625438931
+		popw.local.13
+
+		push.1413652451.2028688940.914536411.3663570513
+		popw.local.14
+		push.1359390184.540478134.1560717999.504399607
+		popw.local.15
+
+		push.743446139.1256465269.1505722664.807802512
+		popw.local.16
+		push.2281574884.3468109719.3811887925.618240864
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 194 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+		push.3750372195.2035230318.3416831941.601913095
+		popw.local.12
+		push.1842401186.770227603.2827187260.3227082663
+		popw.local.13
+
+		push.242037600.3789219983.902632400.1476221585
+		popw.local.14
+		push.835993623.237220582.2197896262.359783156
+		popw.local.15
+
+		push.2318448244.2408219374.53137671.2638019734
+		popw.local.16
+		push.4194594061.3046376037.615279429.2416563804
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 195 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+		push.3175147862.3728138803.1983610580.357121855
+		popw.local.12
+		push.4027599687.3801023292.1774418420.164578292
+		popw.local.13
+
+		push.3927628642.2923643026.2221540048.824001450
+		popw.local.14
+		push.2124369539.351079963.3666187436.2299416501
+		popw.local.15
+
+		push.2409085222.2422063545.1256650400.1518733434
+		popw.local.16
+		push.962742343.660648980.2700130693.2711707900
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 196 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+		push.746273230.2552422355.395058354.2609693913
+		popw.local.12
+		push.2828607444.444006774.1153496959.1413033905
+		popw.local.13
+
+		push.164954283.80506484.453749957.1446473025
+		popw.local.14
+		push.275398732.2538348840.2868690151.3827840943
+		popw.local.15
+
+		push.3074152882.2072717813.1590290827.2333139902
+		popw.local.16
+		push.3621729482.2930415939.2210283962.3497752647
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 197 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+		push.2794198664.533667712.761606379.1284702956
+		popw.local.12
+		push.1504096042.2812881928.1080060923.123366491
+		popw.local.13
+
+		push.2275477839.2837850480.1655960220.3845945523
+		popw.local.14
+		push.2463504785.749985839.1670927809.292870484
+		popw.local.15
+
+		push.3304257464.2537616956.3512623498.2126195581
+		popw.local.16
+		push.3006788464.3922936714.1990865200.2159906753
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 198 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+		push.43181145.4271512875.2992013953.537063912
+		popw.local.12
+		push.78198817.2773655847.289346104.4040893901
+		popw.local.13
+
+		push.1195938999.664763569.2142080281.1258390353
+		popw.local.14
+		push.1096473223.106254079.3522501426.4186953790
+		popw.local.15
+
+		push.1047209446.531143364.2798678993.1854873699
+		popw.local.16
+		push.922640438.3326491725.4148951913.1012599717
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 199 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+		push.1528193762.2689884256.1394603683.2276308131
+		popw.local.12
+		push.2113559319.2261662807.3965887726.35353300
+		popw.local.13
+
+		push.1566331759.3357417936.2272206374.787274229
+		popw.local.14
+		push.1371849441.2697974248.1265922011.1226939181
+		popw.local.15
+
+		push.297107756.3142666049.1608657079.2573568521
+		popw.local.16
+		push.729134313.2172017006.109797606.507719978
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 200 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+		push.2009071546.2341486324.2515248183.2860729139
+		popw.local.12
+		push.4135990155.2603221192.1058306199.1888557965
+		popw.local.13
+
+		push.1367445881.2565299343.3139984011.1160618095
+		popw.local.14
+		push.2965608115.4081526807.48830403.4014754019
+		popw.local.15
+
+		push.297587544.794473728.3611244036.4070224159
+		popw.local.16
+		push.2907005800.3502237281.653703936.929946483
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 201 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+		push.3937457711.4137541527.992063813.3193654052
+		popw.local.12
+		push.2755496574.3519788633.919533222.2648912988
+		popw.local.13
+
+		push.4092280765.294278980.2162967043.481098861
+		popw.local.14
+		push.777643555.1501562020.3846194279.1527473716
+		popw.local.15
+
+		push.511275850.3175558769.59135097.1287659454
+		popw.local.16
+		push.4095764453.1533214482.2510953440.1704507751
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 202 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+		push.1899817798.570856509.2225898115.1051650494
+		popw.local.12
+		push.357330906.2785149658.606444315.2714856291
+		popw.local.13
+
+		push.1879631097.952270060.2774695162.3321241734
+		popw.local.14
+		push.749411667.3913905385.907503122.3793819610
+		popw.local.15
+
+		push.3359107157.3007700557.3168195456.4285623041
+		popw.local.16
+		push.3766550217.457602604.1788386326.4160827950
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 203 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+		push.2791808198.843805962.1860090059.2571212279
+		popw.local.12
+		push.1185184074.3389154792.2460424441.2513942548
+		popw.local.13
+
+		push.2302826707.927635057.3373136182.238398822
+		popw.local.14
+		push.1535892432.3333248629.2043511247.2996391032
+		popw.local.15
+
+		push.2262573183.4251152174.1743670167.868382033
+		popw.local.16
+		push.1391991968.418968215.1137955108.1712255338
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 204 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+		push.3796866466.3100978440.1642197136.4001983926
+		popw.local.12
+		push.3523982667.324696846.3502414063.1131793216
+		popw.local.13
+
+		push.2703094512.2651683439.904102291.626474857
+		popw.local.14
+		push.1993726107.525257035.844979478.3908804621
+		popw.local.15
+
+		push.960803586.695656961.3591234774.663516183
+		popw.local.16
+		push.1524339650.3515735467.3907989411.1648656604
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 205 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+		push.1753919648.3472464120.3151257311.3379514080
+		popw.local.12
+		push.1930059599.3973734754.3106682314.3979222393
+		popw.local.13
+
+		push.2284708863.1803858496.3545549739.1363666819
+		popw.local.14
+		push.1019404486.1111487779.537609494.3812769894
+		popw.local.15
+
+		push.3127807599.3026904391.1976284050.1557420788
+		popw.local.16
+		push.3677926886.1599588132.2158810040.1055178879
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 206 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+		push.3005200779.341834517.3731102939.152763094
+		popw.local.12
+		push.3042735058.2851463274.777765340.4221346227
+		popw.local.13
+
+		push.2822804352.935637314.1440711465.507956193
+		popw.local.14
+		push.2549414397.4105828035.3476228308.2978303903
+		popw.local.15
+
+		push.2710768741.1616025433.546954416.3238254469
+		popw.local.16
+		push.3922987158.108814019.3777734856.1485000560
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 207 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+		push.944386678.2591633282.2504235071.567042626
+		popw.local.12
+		push.3046272278.358626846.3829258050.465812374
+		popw.local.13
+
+		push.1620766189.966940869.3245372610.1886152893
+		popw.local.14
+		push.3072009580.3143783003.1329858866.2689904133
+		popw.local.15
+
+		push.1916025323.3701044413.1319585839.581894166
+		popw.local.16
+		push.3644518502.3732852513.2357128332.676331823
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 208 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+		push.2678622688.3066821601.3289052211.1248206257
+		popw.local.12
+		push.2745366506.788658156.4242112957.1630977282
+		popw.local.13
+
+		push.1351166256.4196881392.4253428350.691124095
+		popw.local.14
+		push.1349780974.3226205716.1817358996.4235352499
+		popw.local.15
+
+		push.3634193660.3190442493.882081595.3933680047
+		popw.local.16
+		push.448452926.3450985026.545514550.1201359236
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 209 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+		push.3709690563.549902884.2242194635.3739298855
+		popw.local.12
+		push.1799760839.3078682677.257258660.3762238685
+		popw.local.13
+
+		push.2563189470.1125728355.514083020.1124353541
+		popw.local.14
+		push.1582405283.1264767328.2941904606.3536469041
+		popw.local.15
+
+		push.3731963929.2323396206.2647609854.3694143483
+		popw.local.16
+		push.1137057888.3435405761.3469613410.4027296466
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 210 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+		push.4199822673.1305699101.2627451673.1788150534
+		popw.local.12
+		push.2573329529.3620885480.3216520821.1841945980
+		popw.local.13
+
+		push.2113111837.3665021265.3786338608.2298153658
+		popw.local.14
+		push.2749272991.475310084.1967848598.3955805843
+		popw.local.15
+
+		push.169444817.3905741579.2645439209.3030101236
+		popw.local.16
+		push.3232692885.874595634.1944852801.2608688031
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 211 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+		push.961640246.51821053.138878530.390826772
+		popw.local.12
+		push.4146647688.321033063.3510968976.1278862182
+		popw.local.13
+
+		push.3366766502.395764187.954202289.3986851759
+		popw.local.14
+		push.2883001739.3082794671.893382718.1944452668
+		popw.local.15
+
+		push.4043525414.2412876685.760012657.2626059230
+		popw.local.16
+		push.782566951.2414451749.4244166595.352177853
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 212 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+		push.1148365313.1962968134.3158968015.3323963493
+		popw.local.12
+		push.404697502.4222226879.2229875264.2115445635
+		popw.local.13
+
+		push.1018428010.4294608175.2915772725.371340867
+		popw.local.14
+		push.1666337119.1857063562.1929182677.3511332175
+		popw.local.15
+
+		push.162436098.2772186275.1292462380.143237952
+		popw.local.16
+		push.369979095.3342424120.2515577834.1403293456
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 213 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+		push.3424082514.4080715965.3000272381.3577648268
+		popw.local.12
+		push.1678891300.819802084.920288413.3498333264
+		popw.local.13
+
+		push.2420714952.2494664294.724965712.1669008241
+		popw.local.14
+		push.3961653970.3838159997.2970253599.551021872
+		popw.local.15
+
+		push.2694474090.2557326045.3137518526.1240269207
+		popw.local.16
+		push.234676145.256884026.52202501.2637262269
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 214 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+		push.1540982819.563906995.2621622873.2673274228
+		popw.local.12
+		push.2356036762.1457047634.512843067.1519128330
+		popw.local.13
+
+		push.4061702105.2478974976.3800309872.4008860087
+		popw.local.14
+		push.1181699429.728245551.2540259105.2906420700
+		popw.local.15
+
+		push.2816355724.2744258411.3202744668.273468686
+		popw.local.16
+		push.3268333994.571220065.3904133961.3395645609
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 215 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+		push.4139238349.1361599354.37455998.3200970598
+		popw.local.12
+		push.1010136976.1404985580.2472469719.2305540222
+		popw.local.13
+
+		push.2276306899.4273564593.3138368756.2245223051
+		popw.local.14
+		push.163846830.2984106568.2436399119.723651998
+		popw.local.15
+
+		push.1391979527.3517663363.2608650452.500316234
+		popw.local.16
+		push.1441413985.3953059213.1252344493.2181548730
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 216 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+		push.2723511710.785436091.4285435836.2664086282
+		popw.local.12
+		push.1560499650.1461437121.1617265066.3947089685
+		popw.local.13
+
+		push.1088185355.755614813.754609756.489027891
+		popw.local.14
+		push.2374461209.724323246.358319328.2136780222
+		popw.local.15
+
+		push.701699999.2490924057.1701631579.1848505821
+		popw.local.16
+		push.2063127465.2224776754.1565274094.3545492585
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 217 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+		push.393331917.1230104509.1986738288.684678892
+		popw.local.12
+		push.80742189.1742470463.2487963811.542276317
+		popw.local.13
+
+		push.247839968.1766270459.2199432616.2631364854
+		popw.local.14
+		push.2500058319.234254723.3250006028.1217549160
+		popw.local.15
+
+		push.3550263079.401677998.130708854.1190102107
+		popw.local.16
+		push.1300072616.4201990711.2009407974.3082548322
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 218 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+		push.3057766773.4023342987.1295014553.1623217457
+		popw.local.12
+		push.111634516.1421316653.1439001701.3091605826
+		popw.local.13
+
+		push.3480440260.3405352696.2661974644.468622153
+		popw.local.14
+		push.260641556.2496893679.3476882565.3732026979
+		popw.local.15
+
+		push.2814366575.338306934.3219690755.1730228237
+		popw.local.16
+		push.469751094.3697464372.1551273632.573613102
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 219 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+		push.3842938795.4178807336.2829082774.3289599419
+		popw.local.12
+		push.2798859732.1220532324.2329473049.133202497
+		popw.local.13
+
+		push.4069356548.2469839957.3755579156.283024429
+		popw.local.14
+		push.3016354591.44723240.2457111193.1354843961
+		popw.local.15
+
+		push.1140131025.2664272694.4042707573.1300593223
+		popw.local.16
+		push.958277381.365702046.4274926853.2376482223
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 220 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+		push.464777089.1461079999.2740814415.1187689149
+		popw.local.12
+		push.960838446.1836940398.424939287.2849959135
+		popw.local.13
+
+		push.1005648548.772407716.4133727180.4111104471
+		popw.local.14
+		push.1418563290.1315618897.1933499394.1508391442
+		popw.local.15
+
+		push.3662878119.3108233390.685642640.2625539939
+		popw.local.16
+		push.619358414.664394475.511703192.920858191
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 221 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+		push.3855110489.3147500082.1522595904.3128843599
+		popw.local.12
+		push.1651729448.3731468053.2542904658.689898465
+		popw.local.13
+
+		push.4289112270.68670616.23969732.3865912684
+		popw.local.14
+		push.1759826544.316908183.3833032603.3731983950
+		popw.local.15
+
+		push.1846915631.2480097620.3577698349.1218544893
+		popw.local.16
+		push.2124892802.2899790009.2373233225.1730219547
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 222 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+		push.3865600976.603315528.3245510671.111278871
+		popw.local.12
+		push.632279119.1370910167.4039663956.719823411
+		popw.local.13
+
+		push.3150505212.4267463796.2459992470.3411277296
+		popw.local.14
+		push.318687452.3388583126.300732715.425100883
+		popw.local.15
+
+		push.1275201972.1305465818.3683011006.1446705965
+		popw.local.16
+		push.3346616811.3216959112.2078620749.2753226745
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 223 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+		push.2341314972.3300661555.3892604075.2474469554
+		popw.local.12
+		push.3438186533.3198272125.3341330868.1686941612
+		popw.local.13
+
+		push.2837592290.204070225.1406493533.1942656126
+		popw.local.14
+		push.3957186729.966814106.992304085.139003780
+		popw.local.15
+
+		push.2014404186.1887722909.2317691624.1350491520
+		popw.local.16
+		push.1283706606.3295423973.3568559575.1861829897
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 224 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+		push.2981892650.2535214426.1915130.2331001822
+		popw.local.12
+		push.567437848.2995526766.2847237315.2622486040
+		popw.local.13
+
+		push.1215951813.877552417.1465680632.3361307245
+		popw.local.14
+		push.2613008707.2408629383.782285353.2614556985
+		popw.local.15
+
+		push.2460030714.1975634687.4270931590.488120361
+		popw.local.16
+		push.2927900728.1787920961.3664883545.2899562836
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 225 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+		push.166152820.126492444.3378668395.3728748438
+		popw.local.12
+		push.4110198145.265313956.1030822644.3157944671
+		popw.local.13
+
+		push.3638450560.358157191.3656970576.3929909964
+		popw.local.14
+		push.2622345671.3598831914.3446802864.848772170
+		popw.local.15
+
+		push.871910711.3417036522.3716385505.11888219
+		popw.local.16
+		push.1550977805.4289205885.444496993.1310459352
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 226 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+		push.2960453830.2210002259.1041747012.1992207679
+		popw.local.12
+		push.3511077045.391731676.2114939200.1162785720
+		popw.local.13
+
+		push.2930006168.3054251558.2078032525.3244059987
+		popw.local.14
+		push.2536534403.505612747.2062700618.3027380143
+		popw.local.15
+
+		push.3522965948.764856879.593559903.3828491558
+		popw.local.16
+		push.2544895281.1372106970.607553643.1563159011
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 227 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+		push.4087716062.2668216568.526152869.888742082
+		popw.local.12
+		push.473050634.1327384209.1142353387.380473373
+		popw.local.13
+
+		push.2434216359.496275057.1933866306.1803642124
+		popw.local.14
+		push.1347635321.88934206.841531409.3640535427
+		popw.local.15
+
+		push.1303125934.658550511.3729257464.449156268
+		popw.local.16
+		push.3036687300.1450173606.3975698908.1522027464
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 228 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+		push.32854073.2878296021.3561173503.3952815453
+		popw.local.12
+		push.435404112.528732176.382744961.1292144435
+		popw.local.13
+
+		push.3295925767.3946554521.1314482235.1870569031
+		popw.local.14
+		push.22636217.778760472.3049304537.725737798
+		popw.local.15
+
+		push.3210442343.693589582.3463222115.3295249715
+		popw.local.16
+		push.3034026076.3366514620.2160857415.3009457335
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 229 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+		push.207475880.467262689.1819604680.1583971742
+		popw.local.12
+		push.3937302361.737404085.4190399179.479949600
+		popw.local.13
+
+		push.2026878265.2908214774.3812050392.1297388559
+		popw.local.14
+		push.790274957.3591717566.1047017917.1041308951
+		popw.local.15
+
+		push.1947392460.1884313194.2173431365.3204094193
+		popw.local.16
+		push.2985226199.2248995759.457946349.1557038245
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 230 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+		push.1327974982.1428826325.3546421227.1266067080
+		popw.local.12
+		push.1016784963.410975754.224598369.2580931274
+		popw.local.13
+
+		push.2495624436.1647388031.1511859266.280173054
+		popw.local.14
+		push.2456973078.2128068043.2059065613.1157878633
+		popw.local.15
+
+		push.2713474275.782135120.2053262251.3868711215
+		popw.local.16
+		push.4004524983.4174461079.3988751163.156028962
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 231 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+		push.2086866628.3272630700.4108735625.295045197
+		popw.local.12
+		push.2309280304.3198409078.1202556162.700149846
+		popw.local.13
+
+		push.1788926764.2139295993.4189083365.3900432388
+		popw.local.14
+		push.770847453.783940588.3137890895.1383720232
+		popw.local.15
+
+		push.4137726641.829881322.1007667761.3831585089
+		popw.local.16
+		push.321435440.1673620386.3066610418.642630809
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 232 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+		push.624042286.3813467983.4046361439.1144938196
+		popw.local.12
+		push.1542529012.3920563771.3459154938.773685725
+		popw.local.13
+
+		push.3479144599.1082334498.2530672539.205485172
+		popw.local.14
+		push.542557784.4144894945.2539825585.48094730
+		popw.local.15
+
+		push.12546364.982720382.3225927904.1347277555
+		popw.local.16
+		push.1336310405.1425090978.333090010.3184174827
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 233 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+		push.1944122387.1246899064.3398560350.4021755929
+		popw.local.12
+		push.1055578266.82611738.3651300217.1308391227
+		popw.local.13
+
+		push.159696631.1267857207.1158643478.1694566227
+		popw.local.14
+		push.834094117.528954524.1473403046.1504553596
+		popw.local.15
+
+		push.571084896.2664177070.1203162646.1542631252
+		popw.local.16
+		push.1918978714.3948082086.2498028497.3837142776
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 234 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+		push.788550021.1382601951.2554306479.3575808578
+		popw.local.12
+		push.3965394424.410154417.3538308522.1717240069
+		popw.local.13
+
+		push.459952549.2220102209.1285588733.4209046487
+		popw.local.14
+		push.2258770410.3759763491.3650017203.744570486
+		popw.local.15
+
+		push.3318792945.4120823233.1754638116.282802467
+		popw.local.16
+		push.3770223320.2443982963.3790433734.1492334047
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 235 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+		push.2456990921.3490595374.2440218892.185657090
+		popw.local.12
+		push.4022887874.3403222840.159883978.1398586648
+		popw.local.13
+
+		push.1719659685.449596210.1812659793.1211636195
+		popw.local.14
+		push.2454272254.2759588628.1899557210.2792843025
+		popw.local.15
+
+		push.2556246659.92046245.3653694776.2204048581
+		popw.local.16
+		push.3053492399.3234452290.3725204268.3082597979
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 236 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+		push.3598304296.1678631941.500566584.1639362574
+		popw.local.12
+		push.529533830.641169704.3930210021.2977723362
+		popw.local.13
+
+		push.1625996265.836178867.3784638064.140279558
+		popw.local.14
+		push.3812010854.2404766051.490309801.3215846786
+		popw.local.15
+
+		push.736454246.2397184556.890213241.2975327423
+		popw.local.16
+		push.3897978566.2467883603.1025626003.3134316404
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 237 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+		push.694248678.2208979821.2467480025.2867378887
+		popw.local.12
+		push.3863856840.2435457769.2371609754.3264611457
+		popw.local.13
+
+		push.1053158028.1666660416.1208633703.3234466328
+		popw.local.14
+		push.1038773072.1920588852.1257037570.1001181507
+		popw.local.15
+
+		push.3933715661.3963583371.878384267.3775858351
+		popw.local.16
+		push.2225412875.2928183305.1298488813.761888910
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 238 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+		push.2866089984.1824562789.3963157458.3758632050
+		popw.local.12
+		push.3683708503.3675594325.1617746195.3389854201
+		popw.local.13
+
+		push.3287628350.3129624068.525968774.2687896166
+		popw.local.14
+		push.3944558367.2803630483.1001194909.2612394886
+		popw.local.15
+
+		push.1967622689.1067891404.789799845.1906378354
+		popw.local.16
+		push.3522173991.2023314688.337772967.3390295520
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 239 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+		push.2491695632.1837210206.1833290135.1771847585
+		popw.local.12
+		push.3375098642.646313020.1794406009.2432931828
+		popw.local.13
+
+		push.2865456065.3704137580.3335499609.2096130576
+		popw.local.14
+		push.369895413.3638006788.3180312665.852362182
+		popw.local.15
+
+		push.2013116127.942897994.521384611.3818734666
+		popw.local.16
+		push.2635234702.248663915.1231597263.3199395814
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 240 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+		push.1039953386.4252472174.947949313.61819516
+		popw.local.12
+		push.3467610694.2330225310.3594111511.727250670
+		popw.local.13
+
+		push.997860002.2213288659.3778419282.1398914528
+		popw.local.14
+		push.3666167054.3859872276.1777208133.425280949
+		popw.local.15
+
+		push.3696765434.2214283621.522385123.1288882766
+		popw.local.16
+		push.1526077311.2666406927.1430060802.297533935
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 241 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+		push.4063583217.465614150.3479138163.3385406759
+		popw.local.12
+		push.817961294.233589856.3957239612.215427003
+		popw.local.13
+
+		push.3765662067.2456443598.847343643.2448510023
+		popw.local.14
+		push.3348224685.3067161788.3313004782.2588581966
+		popw.local.15
+
+		push.1362452159.2118801839.3206811157.2633066603
+		popw.local.16
+		push.590932232.3439296894.2929528507.2541614374
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 242 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+		push.3144493745.2381952902.2629256137.2857567580
+		popw.local.12
+		push.1249714618.745770454.153252740.2819930461
+		popw.local.13
+
+		push.2101402377.268059336.3624308985.3465908484
+		popw.local.14
+		push.1867739315.41237985.2038363597.2440212436
+		popw.local.15
+
+		push.2531269453.256614732.315908841.152364702
+		popw.local.16
+		push.1912206721.1463429452.3613798737.27046412
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 243 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+		push.1976086277.180504913.1530408794.1459183005
+		popw.local.12
+		push.104013554.1758500829.3420551470.4017437352
+		popw.local.13
+
+		push.806461130.3624581514.2911627493.3192496244
+		popw.local.14
+		push.2381579073.4129492154.3430521627.2014044312
+		popw.local.15
+
+		push.900860937.3301129074.104737844.1761853537
+		popw.local.16
+		push.1406194949.797375917.4197616069.73120315
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 244 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+		push.833904658.2913879953.3083685625.3003126163
+		popw.local.12
+		push.972964336.1343764905.1839974576.2572304389
+		popw.local.13
+
+		push.1646328101.1156880648.1150213804.3195028175
+		popw.local.14
+		push.1388646176.451875476.3347613652.2311582805
+		popw.local.15
+
+		push.1103730782.1836000606.3578579675.4135321180
+		popw.local.16
+		push.374212451.1344010413.3803115775.1995055872
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 245 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+		push.593823559.3592854855.213157084.829358460
+		popw.local.12
+		push.2413437811.4091633862.4236386153.4097743837
+		popw.local.13
+
+		push.1675201847.2473958234.1620101697.1831612855
+		popw.local.14
+		push.3992973367.2165149480.2506500644.2182645161
+		popw.local.15
+
+		push.1213798187.3810118122.3504956936.3007403676
+		popw.local.16
+		push.1092410868.1923897824.4285951771.2731199034
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 246 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+		push.726578974.4271386481.664798730.2697487178
+		popw.local.12
+		push.4288982374.1217574074.2438325053.1113015771
+		popw.local.13
+
+		push.651324272.4179278148.3433441038.2462280092
+		popw.local.14
+		push.1679381327.2523859344.3072468730.3524156261
+		popw.local.15
+
+		push.1820294664.3746044143.4125010121.2748068242
+		popw.local.16
+		push.182141876.3946645722.2341983359.3819303925
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 247 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+		push.1195395795.847173656.1042229407.2353048631
+		popw.local.12
+		push.3350594128.3474745972.613125519.2325069777
+		popw.local.13
+
+		push.1534805690.2618857725.3635522397.3957448775
+		popw.local.14
+		push.2755468688.3198554212.4084634815.1110277604
+		popw.local.15
+
+		push.3052656681.1734130525.1880055269.9702456
+		popw.local.16
+		push.3016661756.1200649498.2634850411.2747110743
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 248 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+		push.149847018.43710904.573475438.400924673
+		popw.local.12
+		push.1309563026.2185586142.1795152983.3760278552
+		popw.local.13
+
+		push.254103738.3976447841.1058597257.3095710914
+		popw.local.14
+		push.405048047.3452456883.4267489721.4202926471
+		popw.local.15
+
+		push.2192058477.3713811608.1874616361.255158776
+		popw.local.16
+		push.2078975623.3619671174.3899400560.2278612219
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 249 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+		push.2873818992.560017005.1390537144.642877591
+		popw.local.12
+		push.3723744963.1747847880.3310452633.287120923
+		popw.local.13
+
+		push.3640696437.2333975126.1615022893.2504190400
+		popw.local.14
+		push.2448680816.3412922716.3327752223.2373494510
+		popw.local.15
+
+		push.2518000253.3024655185.1574652291.1534474891
+		popw.local.16
+		push.3456486173.3694082533.2328185985.2920466896
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 250 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+		push.3936742919.2772104824.1196829250.1483635998
+		popw.local.12
+		push.869397318.93253300.3475188449.1370550567
+		popw.local.13
+
+		push.845534863.4292867044.310255275.3021409946
+		popw.local.14
+		push.2912786659.1744005957.3445828053.1075248618
+		popw.local.15
+
+		push.417790438.2317439352.3958708618.1110650634
+		popw.local.16
+		push.2328084612.418074529.1301558259.1427548481
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 251 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+		push.2983034454.2629555476.1952408093.4166516135
+		popw.local.12
+		push.3459834965.3557149523.3355988002.212343495
+		popw.local.13
+
+		push.371813147.4208145029.1144509954.2115803330
+		popw.local.14
+		push.13657435.466709090.2331149592.3083955378
+		popw.local.15
+
+		push.550748983.1200583051.3108496349.1708525255
+		popw.local.16
+		push.3408819858.13908515.2830929943.1925067160
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 252 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+		push.3164290634.2510017135.1351906398.275052315
+		popw.local.12
+		push.3768343242.327112700.2467568403.1541255891
+		popw.local.13
+
+		push.1321637484.1327030418.2902000148.4053141646
+		popw.local.14
+		push.3565840709.2591895807.2473095747.4046137811
+		popw.local.15
+
+		push.2825534215.1305880981.842187130.934957739
+		popw.local.16
+		push.4095046996.2141155988.1989873639.1098634363
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 253 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+		push.1360840567.3731071105.615689712.1958952143
+		popw.local.12
+		push.1484680481.1136445883.4106450200.2612850720
+		popw.local.13
+
+		push.2618960121.3277112134.2548144913.2302900082
+		popw.local.14
+		push.637941066.4262787880.2876205873.3838430350
+		popw.local.15
+
+		push.1499295070.3971437743.2217725047.3276766074
+		popw.local.16
+		push.4246773447.3551240214.3835261861.215608593
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 254 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+		push.2181186994.1882380144.1948365018.2310826502
+		popw.local.12
+		push.3919977144.392046710.1215837599.1895884648
+		popw.local.13
+
+		push.2840054024.3362847970.549055994.1698803586
+		popw.local.14
+		push.2764786988.2255507265.534201118.1268406717
+		popw.local.15
+
+		push.949930655.1858648483.3255479703.636270793
+		popw.local.16
+		push.3321753728.3417442410.95544364.560677759
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 255 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+		push.2518893645.1449684363.4238272990.1568923791
+		popw.local.12
+		push.1486287845.3004908234.1106597725.778081023
+		popw.local.13
+
+		push.112682241.1539449350.22356095.833785547
+		popw.local.14
+		push.3795524707.3432807938.3464672759.1770073772
+		popw.local.15
+
+		push.2390137912.1282011242.2190683269.3442419054
+		popw.local.16
+		push.1767015067.3527058907.3725831105.456741272
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  dup
+  pushw.local.0
+  movup.4
+  popw.mem          # write x[0..4] to memory
+
+  dup.1
+  pushw.local.1
+  movup.4
+  popw.mem          # write x[4..8] to memory
+
+  dup.2
+  pushw.local.2
+  movup.4
+  popw.mem          # write y[0..4] to memory
+
+  dup.3
+  pushw.local.3
+  movup.4
+  popw.mem          # write y[4..8] to memory
+
+  dup.4
+  pushw.local.4
+  movup.4
+  popw.mem          # write z[0..4] to memory
+
+  dup.5
+  pushw.local.5
+  movup.4
+  popw.mem          # write z[4..8] to memory
 end

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -9882,7 +9882,7 @@ end
 # coordinate is represented in Montgomery form, as eight 32 -bit limbs. Note, this is where
 # output will be written, so called is expected to read doubled point from last 6 memory addresses.
 #
-# Expected stack during invokation of this routine:
+# Expected stack during invocation of this routine:
 #
 #   [x_addr[0..4], x_addr[4..8], y_addr[0..4], y_addr[4..8], z_addr[0..4], z_addr[4..8], 
 #     x3_addr[0..4], x3_addr[4..8], y3_addr[0..4], y3_addr[4..8], z3_addr[0..4], z3_addr[4..8]]
@@ -9892,7 +9892,7 @@ end
 #
 # Output:
 #
-# Last 6 memory addresses of 12 memory addresses which were provided during invokation, where resulting doubled
+# Last 6 memory addresses of 12 memory addresses which were provided during invocation, where resulting doubled
 # point is kept in similar form. For seeing X3, Y3, Z3 -coordinates of doubled point, one needs to read from
 # those 6 memory addresses.
 #
@@ -10106,7 +10106,7 @@ end
 # memory addresses holding x, y, z -coordinates of second input point & last 6 addresses are for storing 
 # resulting point ( addition of two input points ).
 #
-# Expected stack during invokation of this routine:
+# Expected stack during invocation of this routine:
 #
 #   [x1_addr[0..4], x1_addr[4..8], y1_addr[0..4], y1_addr[4..8], z1_addr[0..4], z1_addr[4..8], 
 #     x2_addr[0..4], x2_addr[4..8], y2_addr[0..4], y2_addr[4..8], z2_addr[0..4], z2_addr[4..8],
@@ -10118,7 +10118,7 @@ end
 #
 # Output:
 #
-# Last 6 memory addresses of 18 input memory addresses which were provided during invokation, where resulting elliptic curve
+# Last 6 memory addresses of 18 input memory addresses which were provided during invocation, where resulting elliptic curve
 # point is kept in similar form. For seeing X3, Y3, Z3 -coordinates of doubled point, one needs to read from
 # those 6 memory addresses.
 #
@@ -10543,6 +10543,16744 @@ export.point_addition.16
   pushw.local.15
   movup.4
   popw.mem          # write z3[4..8] to memory
+end
+
+# Given a 256 -bit scalar, in radix-2^32 representation ( such that it
+# takes 8 stack elements to represent whole scalar, where each limb is 
+# of 32 -bit width ), this routine multiplies group identity point 
+# ( 0, 1, 0 in projective coordinate system ) with given scalar, producing
+# another point on secp256k1 curve, which will also be presented in projective coordinate
+# system.
+#
+# Input:
+#
+# During invocation, this routine expects stack in following form
+#
+# [Sc0, Sc1, Sc2, Sc3, Sc4, Sc5, Sc6, Sc7, X_addr_0, X_addr_1, Y_addr_0, Y_addr_1, Z_addr_0, Z_addr_1]
+#
+# Sc{0..8}           -> 256 -bit scalar in radix-2^32 form | Sc0 is least significant limb & Sc7 is most significant limb
+# X_addr_0, X_addr_1 -> Resulting secp256k1 point's X -coordinate to be placed, in Montgomery form, in given addresses
+# Y_addr_0, Y_addr_1 -> Resulting secp256k1 point's Y -coordinate to be placed, in Montgomery form, in given addresses
+# Z_addr_1, Z_addr_1 -> Resulting secp256k1 point's Z -coordinate to be placed, in Montgomery form, in given addresses
+#
+# Output:
+#
+# At end of execution of this routine, stack should look like below
+#
+# [X_addr_0, X_addr_1, Y_addr_0, Y_addr_1, Z_addr_0, Z_addr_1]
+#
+# X_addr_0, X_addr_1 -> Resulting secp256k1 point's X -coordinate written, in Montgomery form, in given addresses
+# Y_addr_0, Y_addr_1 -> Resulting secp256k1 point's Y -coordinate written, in Montgomery form, in given addresses
+# Z_addr_0, Z_addr_1 -> Resulting secp256k1 point's Z -coordinate written, in Montgomery form, in given addresses
+#
+# One interested in resulting point, should read from provided address on stack.
+# 
+# This routine implements double-and-add algorithm, while following 
+# https://github.com/itzmeanjan/secp256k1/blob/d23ea7d/point.py#L174-L186 
+export.point_mul.18
+  # identity point of group (0, 1, 0) in projective coordinate
+  # see https://github.com/itzmeanjan/secp256k1/blob/d23ea7d/point.py#L40-L45
+  push.0.0.0.0
+  popw.local.0
+  push.0.0.0.0
+  popw.local.1 # init & cache res_X
+
+  push.0.0.1.977
+  popw.local.2
+  push.0.0.0.0
+  popw.local.3  # init & cache res_Y
+
+  push.0.0.0.0
+  popw.local.4
+  push.0.0.0.0
+  popw.local.5  # init & cache res_Z
+
+  # process bit 0 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+    push.589179219.700212955.3610652250.1216225431
+    popw.local.12
+    push.2575427139.3909656392.2543798464.872223388
+    popw.local.13
+
+    push.2382126429.522045005.2975770322.3554388962
+    popw.local.14
+    push.3477046559.3567616726.1891022234.2887369014
+    popw.local.15
+    
+    push.0.0.1.977
+    popw.local.16
+    push.0.0.0.0
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 1 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+    push.3437933890.2072183026.4256012599.474728642
+    popw.local.12
+    push.617223735.3276311816.1644336685.4191201175
+    popw.local.13
+
+    push.2826781693.3043178571.483526712.3875396767
+    popw.local.14
+    push.1440660280.524996660.3425160008.2758035882
+    popw.local.15
+
+    push.2688095969.1673463056.4082826636.2545792257
+    popw.local.16
+    push.579919648.1848170264.3884180958.2687252166
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 2 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+    push.2879351502.263705507.995471108.1088921762
+    popw.local.12
+    push.2832828146.2614124149.2170633936.2236521962
+    popw.local.13
+
+    push.4073438323.828812798.281675353.2210016624
+    popw.local.14
+    push.581575810.1361063577.1272615727.723804695
+    popw.local.15
+    
+    push.247196370.264991192.1311059568.2063719771
+    popw.local.16
+    push.1352383970.2724730208.2099681297.2989814637
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 3 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+    push.2068125131.1459464947.408359304.1594726639
+    popw.local.12
+    push.3848741185.1749606857.2031190394.2257649329
+    popw.local.13
+
+    push.3779299846.3281205734.1040561013.2394388049
+    popw.local.14
+    push.2749723167.857329376.1744556541.2858939227
+    popw.local.15
+    
+    push.2637562955.3679743535.2221345410.2840325697
+    popw.local.16
+    push.1658585184.2503743746.3205251131.4072748768
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 4 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+    push.1231228381.1813340316.821340817.722512669
+    popw.local.12
+    push.2081094477.3806951506.3254560673.721367143
+    popw.local.13
+
+    push.702108359.3709866115.197069253.2527134796
+    popw.local.14
+    push.2230544006.4199600988.2877849544.2612568121
+    popw.local.15
+    
+    push.1979715416.533757142.870983663.3321979243
+    popw.local.16
+    push.3510650449.435018679.1039046904.1998515401
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 5 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+    push.394522011.3501175395.1444831051.2712217010
+    popw.local.12
+    push.3275764810.1859615953.1889484915.3920395556
+    popw.local.13
+
+    push.3911776812.4104022181.1400047881.2096740742
+    popw.local.14
+    push.1099166461.2723866852.45181322.3558355291
+    popw.local.15
+    
+    push.3573223072.3532032629.752551711.4091923949
+    popw.local.16
+    push.3904370366.3487403656.3148714344.2420508884
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 6 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+    push.1026205514.557988677.1811735612.2526085733
+    popw.local.12
+    push.4256731487.1901518509.4257856434.1704010953
+    popw.local.13
+
+    push.2452202656.1756523026.2650272126.3072086044
+    popw.local.14
+    push.3313277609.3625027388.2823865272.1607317395
+    popw.local.15
+    
+    push.970167946.40178237.1094968387.73287484
+    popw.local.16
+    push.381366728.4201301544.1849045455.3628236831
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 7 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+    push.3457405453.2387867469.2030555195.2314634766
+    popw.local.12
+    push.633324806.2889210420.2971080174.4043757103
+    popw.local.13
+    
+    push.1582281044.3267081159.106787623.2219015849
+    popw.local.14
+    push.2523154591.3118632178.936853110.1450840467
+    popw.local.15
+    
+    push.1975931675.1402488620.1339206136.2915828072
+    popw.local.16
+    push.2281031812.2248683113.1719068146.1024688983
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 8 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+    push.3651363183.836005144.3738400743.1202071911
+    popw.local.12
+    push.3463148253.356534422.2789290949.2123776697
+    popw.local.13
+
+    push.1416992387.4248334506.2282654796.2958880515
+    popw.local.14
+    push.1682858830.972953161.3109216878.2729081681
+    popw.local.15
+    
+    push.1019743195.3715983474.2560515167.3916021123
+    popw.local.16
+    push.57736146.2003662631.1532849746.541811467
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 9 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+    push.1271163719.83748696.1243934934.1725045020
+    popw.local.12
+    push.1757200845.1579712529.3709155749.2490525753
+    popw.local.13
+    
+    push.163567449.2607846704.3022796594.258440691
+    popw.local.14
+    push.3569717.73386979.61235791.1396660245
+    popw.local.15
+    
+    push.1237597377.1596640373.1776096883.628236075
+    popw.local.16
+    push.3366549089.3619273576.2503475385.2238764922
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 10 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+    push.1427940723.7428921.1799368815.1571365520
+    popw.local.12
+    push.2085994872.3160934912.2377651848.3919221800
+    popw.local.13
+
+    push.447109814.1113377320.2767739398.2329310267
+    popw.local.14
+    push.2186442817.2178970503.2795624768.536421003
+    popw.local.15
+    
+    push.1571409508.3157339099.2485825496.1088857644
+    popw.local.16
+    push.3053614628.223221158.4248989966.3480032262
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 11 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+    push.2610818279.3536713782.3912065715.3176669737
+    popw.local.12
+    push.4075424326.2861468264.2826966158.1674842800
+    popw.local.13
+
+    push.3799491819.2512492662.1561581297.1582858834
+    popw.local.14
+    push.3268773358.1186072370.3532693070.1754135012
+    popw.local.15
+    
+    push.3312066550.1673939901.801066763.35873813
+    popw.local.16
+    push.1092243945.4177617868.2411532286.1464808813
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 12 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+    push.2920809398.4247331910.3148245799.620054778
+    popw.local.12
+    push.2717673753.2030337976.2469272834.1039085029
+    popw.local.13
+
+    push.113833265.53899627.2198645230.2433783572
+    popw.local.14
+    push.886461396.99491659.2951913132.3050734995
+    popw.local.15
+
+    push.3796496381.3873867960.4223744311.3807558599
+    popw.local.16
+    push.2453519330.2007784047.757956299.3351232194
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 13 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+    push.1036223050.951134442.706521218.3302693766
+    popw.local.12
+    push.3801555833.606845849.2896886910.209612018
+    popw.local.13
+
+    push.2137706936.1237760563.4027551371.959797812
+    popw.local.14
+    push.355318376.3348606533.26758351.110106597
+    popw.local.15
+
+    push.2950014256.1234570333.3441862140.1884477444
+    popw.local.16
+    push.1071817889.2535981847.620428557.2926284367
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 14 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+    push.3428312537.245232532.159612118.1418946393
+    popw.local.12
+    push.4118717561.2897385214.80459097.551686853
+    popw.local.13
+
+    push.3411429597.4034043018.47726183.1219468969
+    popw.local.14
+    push.1913316320.3313693373.1790647232.3862320970
+    popw.local.15
+
+    push.1080456887.2494968804.2088850801.3335786921
+    popw.local.16
+    push.117479910.4096465048.3748213334.1414641509
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 15 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+    push.617143603.3914299867.973684328.1024725525
+    popw.local.12
+    push.4131906068.3317883546.2714198383.2001977271
+    popw.local.13
+
+    push.3711094428.636908438.3875751458.1202552066
+    popw.local.14
+    push.1739612738.1344947376.1943259727.3984490149
+    popw.local.15
+
+    push.3363774533.3802573440.1406190571.1439164895
+    popw.local.16
+    push.1503048786.2253075200.1799563349.1602884526
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 16 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+    push.375341506.1929451238.2202716750.3251649326
+    popw.local.12
+    push.686489741.1349583.1129616092.580263380
+    popw.local.13
+
+    push.2596216462.3792018179.3285818282.756956372
+    popw.local.14
+    push.2713543322.2042185290.11499049.3239708649
+    popw.local.15
+
+    push.1982999048.864871296.1544240413.3816477355
+    popw.local.16
+    push.2933503355.1150771951.1010323564.4167348229
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 17 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+    push.1995151119.2875022893.4126873466.1465695309
+    popw.local.12
+    push.1176472168.204738826.1035950330.825829971
+    popw.local.13
+
+    push.962013080.3029188982.1759358514.2260129774
+    popw.local.14
+    push.1301017829.149015777.2073426303.2696251698
+    popw.local.15
+
+    push.2208886148.2594586529.1793088961.1024640302
+    popw.local.16
+    push.497957642.409392798.3397792514.121517090
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 18 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+    push.2888001427.725880224.3916942879.2971492725
+    popw.local.12
+    push.840954074.2449757058.1379796681.3174738595
+    popw.local.13
+
+    push.3293155039.1591403760.3205355140.3183698196
+    popw.local.14
+    push.3257309353.2970517532.1632831680.1663479127
+    popw.local.15
+
+    push.3490219988.2976614537.4225664693.115915521
+    popw.local.16
+    push.2881216904.2602803124.1931543326.3882383748
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 19 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+    push.9689525.3726457710.3737655682.334914726
+    popw.local.12
+    push.3876605360.3717017061.1792035884.3658180245
+    popw.local.13
+
+    push.149245088.1699366357.643757068.1988497688
+    popw.local.14
+    push.531073595.2716651538.445341804.376382049
+    popw.local.15
+
+    push.3064552040.1970812605.116048174.2935924752
+    popw.local.16
+    push.3782714730.3644631196.696007875.1704138562
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 20 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+    push.2439832784.2241875899.2018568169.352425916
+    popw.local.12
+    push.4226202437.3446455985.2921220771.2720721362
+    popw.local.13
+
+    push.3280520326.1791571865.3528296494.1537819910
+    popw.local.14
+    push.3416354503.3396109829.1820376351.2676305039
+    popw.local.15
+
+    push.2956912514.1820976906.2858508979.3798288869
+    popw.local.16
+    push.3427443063.2860962761.2699599650.3132555353
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 21 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+    push.2650406160.778134635.1314740119.784819757
+    popw.local.12
+    push.609348168.1469485514.3737623623.3981176228
+    popw.local.13
+
+    push.1725042470.1354922919.3698165144.2935842768
+    popw.local.14
+    push.672254616.2507033870.1329846737.2584119235
+    popw.local.15
+
+    push.672509300.246558793.1700474509.1043351151
+    popw.local.16
+    push.3364027452.3000806926.2213349683.2229151259
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 22 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+    push.1226687375.3732033419.115004589.2189803440
+    popw.local.12
+    push.3426423006.2009945648.1276908713.1016628304
+    popw.local.13
+
+    push.3482569193.4239763898.730303841.2872292874
+    popw.local.14
+    push.2936379902.171638723.2240304277.1414814578
+    popw.local.15
+
+    push.2825705970.894983440.92604647.1669533578
+    popw.local.16
+    push.2164444161.3254136612.31091988.2657278511
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 23 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+    push.1699129945.4088667013.2221645807.2263082900
+    popw.local.12
+    push.3602441774.1079003990.2719087255.2889008302
+    popw.local.13
+
+    push.2240713870.2366730935.1092671880.2600008203
+    popw.local.14
+    push.3624473750.2952716925.3626123566.3939227508
+    popw.local.15
+
+    push.783037882.4180090065.491508136.3319848281
+    popw.local.16
+    push.128933005.1843219761.3178323727.3041293948
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 24 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+    push.3595860352.359733990.1998376628.336093607
+    popw.local.12
+    push.1473277186.516789549.1236670775.3241023408
+    popw.local.13
+
+    push.2295255712.603738871.568714404.91523412
+    popw.local.14
+    push.266020797.1033180496.3919775067.1367605140
+    popw.local.15
+
+    push.2813675221.1303543082.904071087.593415411
+    popw.local.16
+    push.3148124861.38952013.3121562829.308148021
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 25 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+    push.3879371210.3081527059.1276965238.941234928
+    popw.local.12
+    push.1816515825.3248445909.1011391674.510317626
+    popw.local.13
+
+    push.3992782803.3093793053.2242553943.1562562381
+    popw.local.14
+    push.993766506.1627295219.1554902617.629484924
+    popw.local.15
+
+    push.1327291043.217154376.1729612892.1565252408
+    popw.local.16
+    push.2085282704.2941705734.1694467478.2630684944
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 26 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+    push.213605742.3333096384.3217865903.2426287159
+    popw.local.12
+    push.2470191657.1513487983.418351892.1119652998
+    popw.local.13
+
+    push.4180617317.2240474317.2237465588.504535800
+    popw.local.14
+    push.4188015931.1170021009.3217613595.2766194525
+    popw.local.15
+
+    push.2465044802.1876314770.1618583023.4201745150
+    popw.local.16
+    push.352153844.705577837.3808872676.1102893726
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 27 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+    push.2242801002.1887372273.2261272626.697912920
+    popw.local.12
+    push.2111777238.2607907222.1236593688.3793816203
+    popw.local.13
+
+    push.3399380590.1508547522.2142859827.1489169666
+    popw.local.14
+    push.2972896576.3146916577.1550249297.1954517472
+    popw.local.15
+
+    push.1095887046.4032951432.4174004315.2872058775
+    popw.local.16
+    push.3694830907.182787795.2738894540.3036843795
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 28 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+    push.2275040839.2829168165.3451153835.873194490
+    popw.local.12
+    push.3282419999.3093287994.2398937564.1992150115
+    popw.local.13
+
+    push.2736240994.204620363.4198863172.649949720
+    popw.local.14
+    push.3716024826.1233465505.1748859360.1474305547
+    popw.local.15
+
+    push.622684270.4179996509.247155377.2968359192
+    popw.local.16
+    push.3032668618.388189360.2716077947.95629646
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 29 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+    push.2660485347.280790875.789341098.1784021326
+    popw.local.12
+    push.2719014285.1389965106.567774045.2983137038
+    popw.local.13
+
+    push.3906121869.1890695637.1473469579.435252301
+    popw.local.14
+    push.605916942.2000138665.1814215102.3563723739
+    popw.local.15
+
+    push.3606314372.2559042446.2601336813.2405628422
+    popw.local.16
+    push.1746220919.3674660492.3263188964.3563175696
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 30 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+    push.2259138269.1269082684.3518089684.1408579258
+    popw.local.12
+    push.1077170122.2606831513.3331061849.4085012881
+    popw.local.13
+
+    push.3083051596.3455229223.3806463300.1067311995
+    popw.local.14
+    push.1054087177.3996065130.1153902543.1308735309
+    popw.local.15
+
+    push.3427855566.1602100217.508036311.3522943865
+    popw.local.16
+    push.2711196609.1792639260.3615873011.2733173106
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 31 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+    push.3036851339.1923498161.726990368.3678600041
+    popw.local.12
+    push.3425771566.128473889.2514510162.2442663658
+    popw.local.13
+
+    push.1295148995.3086274105.2998223779.3644828036
+    popw.local.14
+    push.325213743.3456678408.1460551922.225117710
+    popw.local.15
+
+    push.3365993235.3060310166.4166074507.1130079062
+    popw.local.16
+    push.1537097577.599500388.3188112682.4220919932
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # drop least significant limb of scalar
+  drop
+
+  # process bit 32 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+    push.4243021446.3930248375.2200770692.1999075395
+    popw.local.12
+    push.129624219.339457830.630538015.3385965042
+    popw.local.13
+
+    push.151326720.2244384650.2564835854.2688349067
+    popw.local.14
+    push.2683751654.671746037.2154085447.4171665086
+    popw.local.15
+
+    push.1973164475.3378236195.1258653325.1576379166
+    popw.local.16
+    push.3350578690.615105488.1907097206.2601362594
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 33 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+    push.3855932326.2341890268.2652231975.2356926667
+    popw.local.12
+    push.155733807.2116491013.4173803077.3196485543
+    popw.local.13
+
+    push.2323633777.1732115118.2807546675.750641548
+    popw.local.14
+    push.1202035494.287739238.571740796.3299463628
+    popw.local.15
+
+    push.2725203297.3303225153.3960676961.1547404409
+    popw.local.16
+    push.201781902.1879208033.366368531.414570348
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 34 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+    push.1163623805.1948397494.3700537393.849137747
+    popw.local.12
+    push.1283932233.3511547519.3538672689.11314807
+    popw.local.13
+
+    push.3902178200.899397401.1257173239.3980824920
+    popw.local.14
+    push.2729188126.1484193751.3310765108.2566167763
+    popw.local.15
+
+    push.2772346691.4292677869.2712131591.1034868192
+    popw.local.16
+    push.3447163093.240345314.298868343.2854454384
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 35 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+    push.490073796.82576743.3736828200.2440595515
+    popw.local.12
+    push.2900988164.93926751.2043608283.742260490
+    popw.local.13
+
+    push.374462255.1803158578.78057496.2160895405
+    popw.local.14
+    push.4246543775.1889068112.279926811.2028601906
+    popw.local.15
+
+    push.2166099010.193908061.2535080685.2680547871
+    popw.local.16
+    push.4240540981.1038306641.45839330.3995232274
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 36 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+    push.3739923889.2737757661.188520867.3134731939
+    popw.local.12
+    push.55085673.21751716.838984379.4037945171
+    popw.local.13
+
+    push.1971945276.1246327437.2318244733.392695281
+    popw.local.14
+    push.339227243.1041902608.1737746765.4234871778
+    popw.local.15
+
+    push.1223845880.3053283226.752051814.2177297027
+    popw.local.16
+    push.2640778917.132490793.363394045.1911428880
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 37 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+    push.732008708.1643820701.1273211715.2564901160
+    popw.local.12
+    push.2194757856.1271759781.3812828764.1428180415
+    popw.local.13
+
+    push.4070648574.1483168998.1858512776.1982122996
+    popw.local.14
+    push.723606342.1797479561.1778447394.695004162
+    popw.local.15
+
+    push.3169832676.3679023124.3388703121.123804462
+    popw.local.16
+    push.1377451392.1184542162.1605555025.2571230163
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 38 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+    push.2831523941.731204757.1174842552.849958179
+    popw.local.12
+    push.1505148098.1765012388.2178624482.91443771
+    popw.local.13
+
+    push.3967207165.3274186100.2836574355.503213154
+    popw.local.14
+    push.133427612.1750317322.3224897846.2169197977
+    popw.local.15
+
+    push.3025821908.3300532140.1772759211.764207700
+    popw.local.16
+    push.4190278158.3792837316.3788873439.820867659
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 39 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+    push.1391526698.1921207145.2742955422.1535773226
+    popw.local.12
+    push.1926013630.484251948.415199817.1631103609
+    popw.local.13
+
+    push.2461586542.2413395531.3976053596.1633706202
+    popw.local.14
+    push.4224874170.263556204.566886706.3338797609
+    popw.local.15
+
+    push.2188414816.1361704363.2222248250.3334053791
+    popw.local.16
+    push.1760021538.1246477538.4020221089.3103984320
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 40 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+    push.1819790809.2178166904.1239928156.1080120604
+    popw.local.12
+    push.2835085961.3716299352.237555353.1921923892
+    popw.local.13
+
+    push.1744963383.712453441.858381141.386431441
+    popw.local.14
+    push.975509937.643555121.2995576306.2581588267
+    popw.local.15
+
+    push.2299504905.3491302099.1827124646.3927673984
+    popw.local.16
+    push.3708375435.2356284909.871247942.462792261
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 41 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+    push.1454822092.3285728435.1378742502.2286879824
+    popw.local.12
+    push.3880482791.3490715278.3102890453.1121678620
+    popw.local.13
+
+    push.1070043390.4062955027.3408978548.2630134036
+    popw.local.14
+    push.4168957777.2777478178.2762588939.635394239
+    popw.local.15
+
+    push.799616421.598310406.3892303814.994983060
+    popw.local.16
+    push.2538873761.635116843.2411495690.1743653792
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 42 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+    push.4064955947.177800874.1883664398.1464320399
+    popw.local.12
+    push.206309447.3076885834.2680212206.2389366466
+    popw.local.13
+
+    push.1916228510.3794860938.87259858.2134340506
+    popw.local.14
+    push.543015909.627283566.3757523287.4037047826
+    popw.local.15
+
+    push.2595402405.1065652033.3754886750.2642017518
+    popw.local.16
+    push.1279883447.1293954212.4182039084.3246576295
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 43 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+    push.3919125906.4277306591.3238831685.2931784487
+    popw.local.12
+    push.3709863201.3778143269.2896263906.125746319
+    popw.local.13
+
+    push.810391584.2694572670.3103996657.1689488452
+    popw.local.14
+    push.1219396925.1173748168.2109412734.2759454143
+    popw.local.15
+
+    push.3012532821.866724528.1718901424.143820326
+    popw.local.16
+    push.1076151823.1869215212.3007531426.1975684790
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 44 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+    push.372104104.1584408275.2944612036.1338203853
+    popw.local.12
+    push.1690494135.638546508.6924999.2818818501
+    popw.local.13
+
+    push.1359135530.3000899183.2440466837.70908625
+    popw.local.14
+    push.3673851801.1115410695.3724980483.3822720403
+    popw.local.15
+
+    push.3963186459.1312373161.3916546418.614671223
+    popw.local.16
+    push.1090101602.1205871786.654432486.3225965430
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 45 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+    push.1455456054.754945335.676985571.2914491643
+    popw.local.12
+    push.1404132585.1151185088.767324933.2333244476
+    popw.local.13
+
+    push.1911268241.1480569170.3584517467.1841579576
+    popw.local.14
+    push.4036200447.1482344847.314907145.2151045431
+    popw.local.15
+
+    push.164251623.2078471405.3328639016.3001905155
+    popw.local.16
+    push.4064832735.3539470659.3958207760.3912356637
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 46 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+    push.3539050180.1781066486.43373161.28255872
+    popw.local.12
+    push.2399604296.182328218.1760516211.1873185083
+    popw.local.13
+
+    push.2124744571.2346921524.2086647707.3681689303
+    popw.local.14
+    push.450074572.1586083369.1057828945.3887057063
+    popw.local.15
+
+    push.1147770607.2748335909.2770239403.2976132499
+    popw.local.16
+    push.15108816.2267610399.3891474949.1238181223
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 47 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+    push.2537906632.3870987310.896931191.2693046389
+    popw.local.12
+    push.3679292966.3415736093.4256668678.1507188281
+    popw.local.13
+
+    push.1171302602.1894168152.3888981693.3119052069
+    popw.local.14
+    push.3098282248.2375464833.2753068900.3096449706
+    popw.local.15
+
+    push.2626062656.2969960579.795045560.1582482099
+    popw.local.16
+    push.209477031.3093707709.4202746756.3588225431
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 48 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+    push.3380407829.1964231819.2385143312.3590821817
+    popw.local.12
+    push.2355394185.2542849143.2322905173.3655294323
+    popw.local.13
+
+    push.865261756.628467235.3534700632.257948540
+    popw.local.14
+    push.388672815.2835872507.1352073514.2642551675
+    popw.local.15
+
+    push.1887798308.15330796.2072835962.3936084927
+    popw.local.16
+    push.3356353071.3616840600.1435566412.1090990745
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 49 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+    push.3027343521.290966086.2290059468.71556765
+    popw.local.12
+    push.1051337337.2228308901.788313012.1252691825
+    popw.local.13
+
+    push.2832582698.829271886.3153051282.1977879392
+    popw.local.14
+    push.2449763730.2394496880.738155419.4236696056
+    popw.local.15
+
+    push.2126009920.674356086.3726766216.3234863489
+    popw.local.16
+    push.3441957840.423571584.1961125286.3816809819
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 50 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+    push.3890280116.2092183917.3197959608.915862962
+    popw.local.12
+    push.3920810919.2647092939.4023234298.842016212
+    popw.local.13
+
+    push.1215912599.969643301.2262906276.3714363160
+    popw.local.14
+    push.474094330.2176442027.1386272556.758145133
+    popw.local.15
+
+    push.2832581714.1028213555.429877432.3895211061
+    popw.local.16
+    push.789267740.3629968881.1664142384.2098587670
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 51 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+    push.69881060.1033278612.3851756353.3366537903
+    popw.local.12
+    push.3056134945.4229139886.939290135.51360330
+    popw.local.13
+
+    push.2281282091.2471339352.3656431778.350550997
+    popw.local.14
+    push.2604912474.1817185359.1717463059.1951395870
+    popw.local.15
+
+    push.733833886.65213119.1910805953.3269891206
+    popw.local.16
+    push.615802927.3298463238.2997144325.3167811090
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 52 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+    push.1515776755.1670037745.3655800101.427888614
+    popw.local.12
+    push.4124258349.3715133632.3652150622.393900791
+    popw.local.13
+
+    push.876551824.4253025791.3370128350.1665076137
+    popw.local.14
+    push.2544117520.3785075401.785316795.3331397673
+    popw.local.15
+
+    push.173736952.1293986505.2136282037.2743837395
+    popw.local.16
+    push.4231928456.2296171318.3702809920.753297862
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 53 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+    push.4206239977.906494042.3036256728.469383574
+    popw.local.12
+    push.1579678045.2422919622.4285065105.4210704817
+    popw.local.13
+
+    push.15182657.551915631.2262568712.2017605335
+    popw.local.14
+    push.2542825453.918556626.2904917918.2336285602
+    popw.local.15
+
+    push.3780185729.913878096.122715666.3011542514
+    popw.local.16
+    push.3507786090.2609550599.2646253414.3308469527
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 54 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+    push.1264250571.2358786109.267699852.397371568
+    popw.local.12
+    push.3637624183.1559805603.1333100442.805741554
+    popw.local.13
+
+    push.1107823231.603239084.382051012.3624661940
+    popw.local.14
+    push.4026394363.3678135263.615594919.2550570861
+    popw.local.15
+
+    push.3127854526.3935157653.3975445554.3336576001
+    popw.local.16
+    push.4086335455.4174644744.2418015280.1854689529
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 55 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+    push.1337257023.2097803714.2186964309.69574727
+    popw.local.12
+    push.2405949463.612439938.1198226394.1290408248
+    popw.local.13
+
+    push.3520181822.1626008312.3556938481.3059913474
+    popw.local.14
+    push.4001034428.3315474656.4050303753.1689644323
+    popw.local.15
+
+    push.3052473835.3237345988.4223460066.4156192200
+    popw.local.16
+    push.394837729.1010332507.3156944571.2143230840
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 56 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+    push.3357835888.1199147507.852159997.1607276660
+    popw.local.12
+    push.1654467477.22959250.3011660105.1915149317
+    popw.local.13
+
+    push.2006818131.2226054321.3408831415.3550900475
+    popw.local.14
+    push.1590292234.3982591116.2110200815.2335589337
+    popw.local.15
+
+    push.1201925116.1539169354.935101213.497800014
+    popw.local.16
+    push.644457494.294749723.3842984229.3525701427
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 57 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+    push.474582552.145974266.481590094.3890661320
+    popw.local.12
+    push.2335629766.3192022847.1485647499.4114042288
+    popw.local.13
+
+    push.234978893.3854381809.3355693258.2862004276
+    popw.local.14
+    push.2410497750.2320046195.131304288.809022823
+    popw.local.15
+
+    push.1318738957.3769892322.3771464647.1936655279
+    popw.local.16
+    push.452052554.2695624202.2696142657.3325074837
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 58 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+    push.1595555664.560100810.3622299272.2184017943
+    popw.local.12
+    push.2460693588.2408572052.1048380281.210768845
+    popw.local.13
+
+    push.2008467572.2467008527.10799570.147667135
+    popw.local.14
+    push.2651068967.917918296.848198734.1676871213
+    popw.local.15
+
+    push.3586907049.3047188635.3344388971.1349055725
+    popw.local.16
+    push.3077906979.887309179.1155359897.3296386596
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 59 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+    push.366266016.2179268796.3962779698.2869202920
+    popw.local.12
+    push.1827635415.4205372956.634973838.2642160681
+    popw.local.13
+
+    push.1391447411.1514973159.3925070901.3714989833
+    popw.local.14
+    push.12096429.937681154.2410134947.3960205325
+    popw.local.15
+
+    push.4006816892.1268487531.920457673.484783460
+    popw.local.16
+    push.2942247545.986635644.1051121938.4283439008
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 60 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+    push.3850750957.2196229415.1401630839.3212445147
+    popw.local.12
+    push.2658904629.3454091496.2807737979.3100099893
+    popw.local.13
+
+    push.2732399273.1682772479.3396290441.2834527101
+    popw.local.14
+    push.1645294878.997276205.634264882.3408792906
+    popw.local.15
+
+    push.3061487694.4147612975.607809775.1089287651
+    popw.local.16
+    push.726014853.2559541446.674293275.701555975
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 61 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+    push.4186698633.1481211838.1371610537.2327704874
+    popw.local.12
+    push.933696081.2439244851.2615315712.913884404
+    popw.local.13
+
+    push.947249811.2187459943.3764781689.1174693308
+    popw.local.14
+    push.2213231104.2298001093.1842716286.1070815964
+    popw.local.15
+
+    push.1042186249.3945050167.2479429112.3552045223
+    popw.local.16
+    push.1766609812.2608568819.1370861363.3300260032
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 62 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+    push.2769350307.3068640479.1693301391.1534698952
+    popw.local.12
+    push.4176795803.3018042694.3874520595.1890360578
+    popw.local.13
+
+    push.2873721938.3342064369.342108151.3423621429
+    popw.local.14
+    push.83989058.2924946953.3482638132.48594429
+    popw.local.15
+
+    push.4092185250.851266439.171714579.3801417272
+    popw.local.16
+    push.2198053893.4122910262.3106106528.71799408
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 63 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+    push.3469890068.3946394267.511676447.3307380463
+    popw.local.12
+    push.3118428633.2959647369.3170637709.3372563825
+    popw.local.13
+
+    push.2054686107.245411910.3303524564.1966565957
+    popw.local.14
+    push.805807871.3470821989.2554015457.3847848274
+    popw.local.15
+
+    push.20693004.2502528377.2409187345.507577010
+    popw.local.16
+    push.3287381371.3514713235.3266414667.3832987379
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 64 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+    push.2105582013.4028571826.1398680223.929018991
+    popw.local.12
+    push.3051371635.2724935968.2360519577.3060172390
+    popw.local.13
+
+    push.1047474443.2470633620.2465897793.1686758339
+    popw.local.14
+    push.1294275752.4173584190.451385138.1139812898
+    popw.local.15
+
+    push.627807224.1897164151.3998369064.3248241325
+    popw.local.16
+    push.4286314443.881422584.1757972216.2844756714
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 65 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+    push.1750856401.854713088.3198409211.390915607
+    popw.local.12
+    push.2780136961.3904655003.1587424501.2652816032
+    popw.local.13
+
+    push.858162732.3912755742.2883780014.189242651
+    popw.local.14
+    push.2159015885.1044022165.2815084326.2219235391
+    popw.local.15
+
+    push.3219804275.4123662966.3658544901.3293455390
+    popw.local.16
+    push.3781102756.230988237.2945637147.2174577042
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 66 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+    push.2748119327.1620764752.2946535205.1489292690
+    popw.local.12
+    push.2548570297.4281812028.48393916.3998577308
+    popw.local.13
+
+    push.2969337763.1464112746.771926169.2799799103
+    popw.local.14
+    push.4002389836.3127936607.3603937497.3005053939
+    popw.local.15
+
+    push.3059474998.1121901657.1019618172.3863235390
+    popw.local.16
+    push.2195337937.783308501.2289061228.771833956
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 67 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+    push.3993810553.3730211394.1937555018.2236390468
+    popw.local.12
+    push.32975235.1901170796.2306495411.2596063487
+    popw.local.13
+
+    push.1226218693.3127214280.3888602397.854560206
+    popw.local.14
+    push.1445606176.2552927947.1547874355.466254502
+    popw.local.15
+
+    push.2989216687.1806064091.1180412485.3220192391
+    popw.local.16
+    push.2790742442.1647864019.3653429430.2226224714
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 68 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+    push.2102862854.4271041081.2471590568.1403471254
+    popw.local.12
+    push.614633720.3576486872.1822861865.1460303818
+    popw.local.13
+
+    push.1165237124.1570111634.1954462842.3022480631
+    popw.local.14
+    push.4280960021.1956846976.150088583.209108884
+    popw.local.15
+
+    push.220540804.3850811378.2558908538.2436681557
+    popw.local.16
+    push.440355473.1420892297.4060729519.104154129
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 69 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+    push.484431564.2490928341.1874515438.4041735840
+    popw.local.12
+    push.2488278332.489109384.2830315848.916058668
+    popw.local.13
+
+    push.4108900642.980052233.2348361273.2734504617
+    popw.local.14
+    push.2945370933.103726037.2975308047.1661158929
+    popw.local.15
+
+    push.3816305847.2405711196.2636355792.2128378950
+    popw.local.16
+    push.193950791.3758628274.1961876981.1054091348
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 70 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+    push.958053770.576130631.4155419959.1787957888
+    popw.local.12
+    push.115473950.822477978.1055291546.2879732828
+    popw.local.13
+
+    push.330852323.2165209260.4186224570.1059145280
+    popw.local.14
+    push.3403575861.3414551909.2845409721.2687779374
+    popw.local.15
+
+    push.4147811819.3812981490.2207581564.3186548262
+    popw.local.16
+    push.765489644.4204278716.420831615.686289746
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 71 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+    push.2407095031.1420560899.2675219549.2301384663
+    popw.local.12
+    push.1320712841.189371538.2462092567.415180916
+    popw.local.13
+
+    push.521573832.2073770098.159582541.1578764349
+    popw.local.14
+    push.790911321.1966535291.4197745626.3797023080
+    popw.local.15
+
+    push.2616179923.2620062287.847843478.3315509977
+    popw.local.16
+    push.346949059.3577731365.3661011466.2278886097
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 72 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+    push.1966465813.604647178.4196749756.789736869
+    popw.local.12
+    push.126499372.2858614875.1820339848.3533311886
+    popw.local.13
+
+    push.1808104770.2360198333.2482638774.3240947624
+    popw.local.14
+    push.3919016294.1315610693.2701541236.3111362429
+    popw.local.15
+
+    push.2709577220.2257654816.2708829808.3649193325
+    popw.local.16
+    push.2686476327.3170189344.2469236587.545799926
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 73 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+    push.3042011166.3980881876.2400451195.756850751
+    popw.local.12
+    push.1673473568.3246396932.3233126230.3694757456
+    popw.local.13
+
+    push.2422798041.605859356.2809127354.1885077772
+    popw.local.14
+    push.3451635145.3395420679.819372650.3183326785
+    popw.local.15
+
+    push.1001075623.1476446167.2116757194.657020538
+    popw.local.16
+    push.2021208394.4189291889.223928975.3084231900
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 74 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+    push.3889031629.3548347718.1528378206.1360271360
+    popw.local.12
+    push.684080650.3020149742.2575799977.4167697701
+    popw.local.13
+
+    push.951728142.863796929.806408025.1349686452
+    popw.local.14
+    push.1442184620.1745833116.3342210715.686503619
+    popw.local.15
+
+    push.1604304220.3213219414.2334978195.3552447160
+    popw.local.16
+    push.3765824723.3094155980.3563201915.2442217768
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 75 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+    push.4092388786.1074258664.4212587402.2823109854
+    popw.local.12
+    push.927854096.3419149860.1413812208.3997738346
+    popw.local.13
+
+    push.3081651707.1870075313.4214507112.2948708405
+    popw.local.14
+    push.1794423875.3659870744.1347323782.30742182
+    popw.local.15
+
+    push.3349180874.284708997.1030669352.852011505
+    popw.local.16
+    push.4025102189.3002044362.2610939516.968481390
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 76 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+    push.4083309621.1354160305.3345691164.3173403818
+    popw.local.12
+    push.275957873.3947229107.2154425801.1891283735
+    popw.local.13
+
+    push.2418964509.3263182117.3449144896.2671288163
+    popw.local.14
+    push.4022591230.2839066415.2079673701.530147430
+    popw.local.15
+
+    push.1620584395.2741203150.830642661.680216962
+    popw.local.16
+    push.57675626.3996181708.447113519.3325652353
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 77 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+    push.2624800978.1576084960.136666640.1429498917
+    popw.local.12
+    push.3977335559.438330674.3975547620.3361329560
+    popw.local.13
+
+    push.1841547412.3167977330.844458091.354057312
+    popw.local.14
+    push.1900090986.2881736842.377646265.755042002
+    popw.local.15
+
+    push.751714457.2921609162.2712683821.2673845263
+    popw.local.16
+    push.3796516846.457878672.3796078088.133390108
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 78 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+    push.2955562702.2067107445.2515787528.3157323974
+    popw.local.12
+    push.1296809448.1251514215.932999437.4048013732
+    popw.local.13
+
+    push.1157975516.2479831368.11565890.2480571873
+    popw.local.14
+    push.411715520.2447522776.2310497932.3781337653
+    popw.local.15
+
+    push.2213739025.2367077836.4120472051.60025773
+    popw.local.16
+    push.2170317792.1249770147.1610165525.10143291
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 79 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+    push.1873016892.2908160895.1761588077.4130817054
+    popw.local.12
+    push.3193794080.3956168732.2400363838.2611008937
+    popw.local.13
+
+    push.4225279449.3309431556.680901258.3062345760
+    popw.local.14
+    push.637579457.1426022496.3552004709.3521666672
+    popw.local.15
+
+    push.2968239279.2710169141.1002962628.2026748420
+    popw.local.16
+    push.3168557127.1599831230.1908704830.3582279181
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 80 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+    push.2147183140.2435889009.1124217110.692822312
+    popw.local.12
+    push.2571300373.2854085925.1206048166.434005132
+    popw.local.13
+
+    push.2437021524.2144223304.1558569048.2321955205
+    popw.local.14
+    push.542993901.1807479648.846889975.3208567005
+    popw.local.15
+
+    push.2536797638.3761558151.361836687.194462540
+    popw.local.16
+    push.45045079.3313636243.4065224498.2317706449
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 81 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+    push.965761796.909881260.423180520.1260309859
+    popw.local.12
+    push.3978895079.955654321.1597674889.2239392442
+    popw.local.13
+
+    push.471537044.4051323466.1851461799.1358762056
+    popw.local.14
+    push.3688744661.713843288.4211114079.4262002280
+    popw.local.15
+
+    push.2313100600.2724345757.1795155454.286184790
+    popw.local.16
+    push.3579288157.2293609170.2944134579.1851177124
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 82 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+    push.4256535327.971953462.2690202946.3464971495
+    popw.local.12
+    push.2792497975.3896150695.2601588359.2455467494
+    popw.local.13
+
+    push.2733669384.1808969764.2545608112.419424531
+    popw.local.14
+    push.200659473.2013938264.4029364271.1302990387
+    popw.local.15
+
+    push.4190172805.3941131213.3879978320.1209185419
+    popw.local.16
+    push.1710544862.3146657047.2110032199.367863398
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 83 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+    push.1043810021.167539280.297646337.3690202998
+    popw.local.12
+    push.1497500411.1425757150.1279677033.1216685214
+    popw.local.13
+
+    push.1490055384.2096715467.4118188432.2731821351
+    popw.local.14
+    push.1452441665.2147736672.3161960445.2412667335
+    popw.local.15
+
+    push.1283118447.724071994.454377685.2305006999
+    popw.local.16
+    push.3916810877.1299080966.4267126602.4134597698
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 84 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+    push.2930319825.4834939.4228156803.3141696362
+    popw.local.12
+    push.316863046.2372232826.538406169.3550510846
+    popw.local.13
+
+    push.1085851922.2152848749.3310053087.1878276787
+    popw.local.14
+    push.2044341764.1844924113.2633437963.1484033813
+    popw.local.15
+
+    push.4142097638.2354980066.2049983884.1728408872
+    popw.local.16
+    push.2226359467.1234800008.836810939.1007386657
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 85 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+    push.2238069073.1972041509.3614873861.3435216957
+    popw.local.12
+    push.3046696047.3996587108.4112183189.3505849815
+    popw.local.13
+
+    push.22096684.207965602.4210943564.3340997638
+    popw.local.14
+    push.146356977.899036247.280471051.1508419602
+    popw.local.15
+
+    push.1045002525.2930492521.2806553287.4230456169
+    popw.local.16
+    push.1767575569.4243592530.3870425872.4279724803
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 86 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+    push.45809781.769357890.2250396233.2343497395
+    popw.local.12
+    push.101061509.1886272056.3632026625.2035677118
+    popw.local.13
+
+    push.3892985643.1103735805.3157116484.2949779894
+    popw.local.14
+    push.4043651060.3495493696.1252064033.2559142819
+    popw.local.15
+
+    push.3381405462.568768815.1920956361.1188271888
+    popw.local.16
+    push.1636722311.1547049913.1160754888.794510130
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 87 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+    push.2054128079.2230972820.1127625440.3877806084
+    popw.local.12
+    push.1946758545.2978678576.1568487482.2887488155
+    popw.local.13
+
+    push.1292508732.2351765213.4022486584.1819066919
+    popw.local.14
+    push.1964184935.398013355.2989388614.815040508
+    popw.local.15
+
+    push.2011046877.707352156.2835874648.1958572988
+    popw.local.16
+    push.1152503915.4109489512.2705616261.150689496
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 88 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+    push.2364000695.2236109412.1337081733.3263008144
+    popw.local.12
+    push.3886166885.1656273194.1512802251.52274770
+    popw.local.13
+
+    push.2069884065.2871037537.4186082752.2270556422
+    popw.local.14
+    push.387208902.2980155850.2638774085.2147884509
+    popw.local.15
+
+    push.2830978373.3036320741.3540631672.1541874332
+    popw.local.16
+    push.2957471010.3524468751.680681556.3448300765
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 89 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+    push.767734023.4279048740.1157535992.2171654129
+    popw.local.12
+    push.963493471.68985541.1043941206.3626189511
+    popw.local.13
+
+    push.1845445059.82835290.3114620409.2927720915
+    popw.local.14
+    push.2519679746.4249792059.1555524640.3524697156
+    popw.local.15
+
+    push.2748829623.455193681.678110168.3855606563
+    popw.local.16
+    push.2420875917.3091767772.949655978.2440506923
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 90 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+    push.434197593.1436116311.2289836964.3641424224
+    popw.local.12
+    push.1157956470.3318692241.1442303333.43200738
+    popw.local.13
+
+    push.1160300146.1726410591.48937343.577065003
+    popw.local.14
+    push.4124851481.861020709.2520462156.1798162091
+    popw.local.15
+
+    push.2076799404.3271195648.3281460968.1433936315
+    popw.local.16
+    push.1834901373.2617710988.668444809.3960149915
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 91 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+    push.3453202519.1562435575.4285537762.2659185081
+    popw.local.12
+    push.2487884998.828076153.310132277.4117694234
+    popw.local.13
+
+    push.266201960.3537383044.3505185577.178631504
+    popw.local.14
+    push.2718144955.1650651555.2495057436.848817746
+    popw.local.15
+
+    push.494832992.1492556077.687268660.1023426763
+    popw.local.16
+    push.751466010.2811067554.949527296.2283947930
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 92 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+    push.2095404446.1325909471.3727571052.929126487
+    popw.local.12
+    push.821705374.3015236194.919943740.3722401695
+    popw.local.13
+
+    push.1152815177.3230722945.2581399890.4065463356
+    popw.local.14
+    push.2657196510.3644453791.2486409935.4039281400
+    popw.local.15
+
+    push.2339612881.3498123033.1366761769.3345003208
+    popw.local.16
+    push.151730902.1032282314.2922436459.1396993633
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 93 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+    push.4106358830.2661783832.3776584720.4129318781
+    popw.local.12
+    push.1990480316.3108426184.484457080.3469856670
+    popw.local.13
+
+    push.3881390677.2376572117.2628585139.771294546
+    popw.local.14
+    push.3898364616.610482295.1020747179.2757049303
+    popw.local.15
+
+    push.420949569.4247993496.3537190828.1313824226
+    popw.local.16
+    push.3343899360.3992358927.2866847288.2632213500
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 94 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+    push.2330202798.3793670437.1666342885.1131528605
+    popw.local.12
+    push.1767690935.150380127.1706638548.1772638692
+    popw.local.13
+
+    push.672412297.364455713.3151016307.1827031164
+    popw.local.14
+    push.3293037610.3985845895.3427308739.2661027154
+    popw.local.15
+
+    push.1868842473.471489517.3240431408.2117560880
+    popw.local.16
+    push.1084586120.702283184.3023486909.3570162450
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 95 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+    push.1517715605.509324179.1071779425.1403370981
+    popw.local.12
+    push.2065572673.98781838.235353061.3408575061
+    popw.local.13
+
+    push.290607056.2277295677.223961665.2214882506
+    popw.local.14
+    push.3423975001.1508641478.573623603.1974865253
+    popw.local.15
+
+    push.56821615.2081436588.1093641110.1777861755
+    popw.local.16
+    push.621790620.1936802240.1529138668.833231145
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 96 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+    push.3946426554.2808424719.4170712750.1543904120
+    popw.local.12
+    push.1983935828.3166429406.2672547269.1527713947
+    popw.local.13
+
+    push.3530652661.3557735053.1335483736.3474816117
+    popw.local.14
+    push.2482778285.2301672744.555633540.2349740190
+    popw.local.15
+
+    push.4111735944.102269432.467635238.1577869094
+    popw.local.16
+    push.999638617.1559089557.3770806934.3380534272
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 97 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+    push.1231664109.567958979.3727734293.2576619508
+    popw.local.12
+    push.3531792766.294827065.1721065140.3213216935
+    popw.local.13
+
+    push.4008534261.3921488869.3560147474.426442631
+    popw.local.14
+    push.4011558202.2993173694.1143099324.3905370773
+    popw.local.15
+
+    push.2544146444.3723219934.1779055491.4059355383
+    popw.local.16
+    push.1106650743.3907097879.3656920813.2999104053
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 98 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+    push.2215681696.1833117381.1052435029.3690170515
+    popw.local.12
+    push.297324649.2974671270.1457728066.1138090666
+    popw.local.13
+
+    push.641339019.3003232328.3827500595.25658289
+    popw.local.14
+    push.831563243.1555017039.562259675.705342321
+    popw.local.15
+
+    push.797713258.2183927562.2593236792.2160162012
+    popw.local.16
+    push.2809668745.4058896609.162130346.1119936282
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 99 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+    push.924747330.3934194257.1669859148.2436061424
+    popw.local.12
+    push.1111412495.845861911.128539704.2889741525
+    popw.local.13
+
+    push.3370732814.2437793624.3666376174.43863592
+    popw.local.14
+    push.3962023612.683497106.846149992.2303458042
+    popw.local.15
+
+    push.654318585.755323251.1176107628.1969179532
+    popw.local.16
+    push.3953355374.2219686724.2563637000.1606929534
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 100 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+    push.2201659057.2876929364.2065398710.2963265494
+    popw.local.12
+    push.2558794243.2635660306.2888006731.3211085519
+    popw.local.13
+
+    push.1861735910.3406293307.3082336510.4276027709
+    popw.local.14
+    push.1053455946.457787251.2252553626.1383432065
+    popw.local.15
+
+    push.631342944.2179504382.237867736.1445969530
+    popw.local.16
+    push.1275109758.885852953.2928852466.2936388372
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 101 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+    push.3611366268.1831994131.1719041647.1954708515
+    popw.local.12
+    push.3834948292.3280602991.1935020228.1650621784
+    popw.local.13
+
+    push.3569846179.679436820.281349768.3622374413
+    popw.local.14
+    push.288620013.3265472674.695666818.3889255464
+    popw.local.15
+
+    push.153990694.4014110973.1595414016.771844077
+    popw.local.16
+    push.2411874093.2682826721.2148243734.3143472347
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 102 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+    push.1466288375.908855089.3324924579.535293732
+    popw.local.12
+    push.4158117360.4027692640.3191217970.2629236568
+    popw.local.13
+
+    push.1500371005.2438658963.3421798001.3568821682
+    popw.local.14
+    push.3944598048.3526935232.1927944567.647231806
+    popw.local.15
+
+    push.3863390043.1626757698.3718359335.286443397
+    popw.local.16
+    push.3946196921.66840545.4253794039.1624065450
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 103 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+    push.1293697378.3746003679.4078024924.2261132022
+    popw.local.12
+    push.3177407800.1971593846.3430148714.1232847134
+    popw.local.13
+
+    push.1101723642.3570553653.2738459880.517023977
+    popw.local.14
+    push.923748974.749916797.1405785536.3348961098
+    popw.local.15
+
+    push.2704435240.1865777396.3198177515.1845975775
+    popw.local.16
+    push.3662249190.2283137214.1717416594.2138980524
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 104 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+    push.2257695780.3150774005.3970001509.4168348331
+    popw.local.12
+    push.2749955548.1442125546.4236912991.100200505
+    popw.local.13
+
+    push.2104758122.1266914505.687082796.2186987764
+    popw.local.14
+    push.1212688125.3562444091.2355173829.2489267689
+    popw.local.15
+
+    push.11268439.1229227033.1848823491.3049245032
+    popw.local.16
+    push.3249571275.2761391695.3028897536.1645505824
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 105 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+    push.3620512607.687083731.3852994955.2277125234
+    popw.local.12
+    push.2134278040.460748037.1514746734.2785187105
+    popw.local.13
+
+    push.2145126067.2053539985.813270778.377203065
+    popw.local.14
+    push.1216944309.1264231549.851526522.816789900
+    popw.local.15
+
+    push.1025218763.1299560201.4136975719.3097106974
+    popw.local.16
+    push.3099910167.2061596049.1531609397.157442371
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 106 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+    push.3003676891.127990804.748619701.2976996008
+    popw.local.12
+    push.4022809935.742879883.1502188510.1162142104
+    popw.local.13
+
+    push.2398274640.4173909105.3120283902.2576244133
+    popw.local.14
+    push.4155118099.2961520377.2637254360.3745765835
+    popw.local.15
+
+    push.3379731892.2891491678.2700850407.1579808355
+    popw.local.16
+    push.2108188033.1928983695.3942998603.2346131303
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 107 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+    push.792361920.300399448.3528400478.669124404
+    popw.local.12
+    push.3732826757.2276102682.1379325263.3526236643
+    popw.local.13
+
+    push.1321914552.2228030794.1514648476.668136951
+    popw.local.14
+    push.172774928.4063155861.1538650176.3299763994
+    popw.local.15
+
+    push.2662587842.1254455581.956335357.1548538666
+    popw.local.16
+    push.1795711342.2558634291.3079953412.4257929129
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 108 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+    push.2484169075.4220766875.1063432399.2900683076
+    popw.local.12
+    push.876509780.1085198534.1102146832.976721406
+    popw.local.13
+
+    push.4214490925.1906562462.1952197157.1599005289
+    popw.local.14
+    push.816218342.3528049166.1917761070.1501245270
+    popw.local.15
+
+    push.3635404226.2982070172.1443269872.2651068343
+    popw.local.16
+    push.2629773589.3749041910.3364031030.298369384
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 109 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+    push.3493933080.2766792520.1426639440.3277093746
+    popw.local.12
+    push.376017388.922017845.3585836087.3945654906
+    popw.local.13
+
+    push.3705085246.3045889630.3524321254.1519051765
+    popw.local.14
+    push.817380573.2501509175.1123613530.3648807890
+    popw.local.15
+
+    push.1923487622.241580526.2065847989.1560490530
+    popw.local.16
+    push.2311622675.3444708254.379693928.1465054857
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 110 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+    push.2488695529.3663340612.9878138.3784070159
+    popw.local.12
+    push.2674156217.1469372807.3351161501.3225878609
+    popw.local.13
+
+    push.1010530692.27495705.3733590032.65894539
+    popw.local.14
+    push.926218107.2885986491.3903999038.755000237
+    popw.local.15
+
+    push.4044202835.2978366651.2847348874.2617971131
+    popw.local.16
+    push.2427931454.3439410609.2632352345.1470675854
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 111 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+    push.2602052011.3107196463.955982553.2298050907
+    popw.local.12
+    push.2104423586.1178437464.3061453190.2781933201
+    popw.local.13
+
+    push.3051807764.633861420.1421982224.1438445533
+    popw.local.14
+    push.2359544288.1627206537.2692092431.373969561
+    popw.local.15
+
+    push.2898145007.3566884982.3505683229.3073794165
+    popw.local.16
+    push.686038994.931702740.147204559.1499823453
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 112 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+    push.120402000.2000063349.472439158.4003562864
+    popw.local.12
+    push.3413780705.1355210406.2383148278.3850206319
+    popw.local.13
+
+    push.2108266665.3112865854.1886498248.149081560
+    popw.local.14
+    push.27736301.4276340165.4084768652.3069971457
+    popw.local.15
+
+    push.1318572848.3513457001.1832881498.2708587029
+    popw.local.16
+    push.3463488704.1232505773.2007544314.4027405309
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 113 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+    push.1490889441.83398646.572879068.370871241
+    popw.local.12
+    push.362474641.1483757299.1482752995.4289161696
+    popw.local.13
+
+    push.1390154626.2657677842.4005475763.1948752428
+    popw.local.14
+    push.1669812522.195298905.2787149535.3114056813
+    popw.local.15
+
+    push.2388212050.419547213.3634128161.2569079333
+    popw.local.16
+    push.665353583.127533633.1733343691.2464992126
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 114 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+    push.1512327570.251195742.3672725365.3383771381
+    popw.local.12
+    push.1167315975.2781533644.3878733038.164402913
+    popw.local.13
+
+    push.1230225231.145414961.2860643194.2019099054
+    popw.local.14
+    push.1490820778.2524040702.2949045560.767323863
+    popw.local.15
+
+    push.3576771338.3293548109.3584476262.3266612892
+    popw.local.16
+    push.3854801163.784757327.3372162199.3147183541
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 115 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+    push.818765039.3092247215.590017123.3800644428
+    popw.local.12
+    push.3954370789.2853133304.3195712977.3596292424
+    popw.local.13
+
+    push.1736809266.3071816178.1369998928.1862080476
+    popw.local.14
+    push.3097072122.2252897532.2190861257.3980304007
+    popw.local.15
+
+    push.684636236.2852573017.3397940335.2943789561
+    popw.local.16
+    push.2972650254.848827651.3722641795.3902348624
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 116 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+    push.2532399528.680289515.2192312939.2841923315
+    popw.local.12
+    push.397116000.2218639206.2832690611.3617536122
+    popw.local.13
+
+    push.393537457.1346087180.3320063252.504978230
+    popw.local.14
+    push.2205536672.1952375961.3659938374.4281808523
+    popw.local.15
+
+    push.4092942795.1020537785.1314760526.2471424123
+    popw.local.16
+    push.1130219357.1877859925.3926463433.655282123
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 117 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+    push.3248842364.2812450433.3832086536.807052468
+    popw.local.12
+    push.3329408522.3747620573.1818430778.4002898834
+    popw.local.13
+
+    push.3373095435.2717381327.1644852652.1600431714
+    popw.local.14
+    push.1115806542.2950317302.2536969431.3057369897
+    popw.local.15
+
+    push.1629769019.3011898360.685922507.795138259
+    popw.local.16
+    push.3196531058.1243515018.1212118128.1471115477
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 118 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+    push.2333030850.1231655529.2534864055.4009649657
+    popw.local.12
+    push.2721338808.1744567649.2473559136.164195959
+    popw.local.13
+
+    push.4250521275.2361364460.1741518331.3877177070
+    popw.local.14
+    push.2340961958.194438317.2612985168.2648169280
+    popw.local.15
+
+    push.1605861937.1181659736.2081551892.3188897533
+    popw.local.16
+    push.2073564389.2689322569.3665402700.3464248338
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 119 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+    push.627313317.2324693906.838202588.1031242801
+    popw.local.12
+    push.247352440.3533768284.4074249497.3822515451
+    popw.local.13
+
+    push.3969186073.3749056353.1434534918.1739538012
+    popw.local.14
+    push.4154659109.3257067329.3752303332.2260462306
+    popw.local.15
+
+    push.3792415994.2730560668.3846001716.3385775570
+    popw.local.16
+    push.139247123.3077903373.3825563731.3705122380
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 120 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+    push.2091545405.1149321410.2586317549.86331127
+    popw.local.12
+    push.1804026901.2277639111.2523741659.2765154580
+    popw.local.13
+
+    push.1407401414.4126905107.2154671797.415548181
+    popw.local.14
+    push.2796857514.634550735.3491693139.1615513233
+    popw.local.15
+
+    push.2687949723.3328125129.1245445180.2378969076
+    popw.local.16
+    push.3271220055.2814967647.1133228357.3315355839
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 121 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+    push.1140001501.286141053.1712538385.2272347811
+    popw.local.12
+    push.69374038.2358553540.282302138.1488056790
+    popw.local.13
+
+    push.2072435197.2947835.1774211538.1275926818
+    popw.local.14
+    push.690226041.343580197.721098191.1047965908
+    popw.local.15
+
+    push.4164151184.1568903507.4057020202.3371225242
+    popw.local.16
+    push.2381289541.3075195764.1635941985.3310123332
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 122 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+    push.1726591552.2103482580.128723946.1664048234
+    popw.local.12
+    push.327901448.678003824.3685820211.3990855054
+    popw.local.13
+
+    push.2654470705.1709740202.371540969.2783616578
+    popw.local.14
+    push.4219313016.116411704.2226511914.1950195406
+    popw.local.15
+
+    push.825432954.3048967297.1526055797.687348508
+    popw.local.16
+    push.547411365.1875091201.3619462357.4238855041
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 123 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+    push.3108746976.2602061706.3020194108.3349542632
+    popw.local.12
+    push.1115573121.1914720819.3608288040.1836825161
+    popw.local.13
+
+    push.2445645117.224857084.4135583575.648792613
+    popw.local.14
+    push.3719755528.2012896675.3479094232.397353366
+    popw.local.15
+
+    push.3818598150.1454216861.2702483629.4212146368
+    popw.local.16
+    push.2098318341.2576522618.2441984467.3299524076
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 124 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+    push.87380209.4078895453.1639366402.91777993
+    popw.local.12
+    push.4036185603.2849598403.1651538958.3087474893
+    popw.local.13
+
+    push.2698799511.492065249.990858129.4131192616
+    popw.local.14
+    push.1142669719.3588887267.3556210923.820810977
+    popw.local.15
+
+    push.3203704518.257684398.1458934746.3968043265
+    popw.local.16
+    push.1047217830.1403044723.2236153565.2418722729
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 125 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+    push.1886596386.3920357886.2925563057.605688704
+    popw.local.12
+    push.3405612224.2129199950.2840531772.3183265187
+    popw.local.13
+
+    push.3888318136.4226168358.3420073953.679473937
+    popw.local.14
+    push.3992001302.2212804034.2533586678.271287025
+    popw.local.15
+
+    push.2127292439.1469394576.593557084.86692016
+    popw.local.16
+    push.4158708877.1241978907.1578478365.3404809454
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 126 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+    push.3061577248.1609110525.1318799245.582470858
+    popw.local.12
+    push.2867019135.601428751.514669271.52087952
+    popw.local.13
+
+    push.2753827489.4037102244.370123499.1248970440
+    popw.local.14
+    push.1276942563.3085068952.3831705189.742553915
+    popw.local.15
+
+    push.1398369724.3222974794.722154086.2489917060
+    popw.local.16
+    push.3406888139.1797554668.2261003503.1606664018
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 127 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+    push.2169819339.3466937103.2726892299.3717659155
+    popw.local.12
+    push.671004760.98858366.1319996870.1510381939
+    popw.local.13
+
+    push.1863818287.2341353042.2056583376.2262508885
+    popw.local.14
+    push.1289271936.1411810320.1612850052.604702419
+    popw.local.15
+
+    push.2903621440.65349278.1738331437.1559951867
+    popw.local.16
+    push.3901108667.2978150578.2140484758.2473618984
+    popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 128 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+		push.792077805.3849054254.3341320233.2298120071
+		popw.local.12
+		push.2143033467.58622371.19193329.435664139
+		popw.local.13
+
+		push.3953373771.2194583657.2145614393.2722813744
+		popw.local.14
+		push.2241673337.116511288.2963824869.3183902225
+		popw.local.15
+
+		push.988674444.1510610333.995649495.846126732
+		popw.local.16
+		push.2895442476.2215110696.3024776878.2014863007
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 129 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+		push.3594205145.3478231389.1726614777.96238121
+		popw.local.12
+		push.3192232650.1975346810.4278687702.1040683771
+		popw.local.13
+
+		push.3736887147.607079206.2057184339.2688177366
+		popw.local.14
+		push.1441664212.2037172208.3858908676.334865804
+		popw.local.15
+
+		push.3476037993.3054816755.98465182.3952008231
+		popw.local.16
+		push.1927827307.2874280551.112860756.1698521712
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 130 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+		push.2091068109.1644290748.3003631132.121358825
+		popw.local.12
+		push.3312469602.2288063290.3837528054.199189819
+		popw.local.13
+
+		push.1908248248.2540102707.3781633004.56254144
+		popw.local.14
+		push.2489532327.770550708.2256565987.956757455
+		popw.local.15
+
+		push.4263111716.487763938.3110394647.554343052
+		popw.local.16
+		push.1933354832.1256628273.216683999.704075843
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 131 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+		push.371645915.2106918511.3162018088.1172841277
+		popw.local.12
+		push.2999380335.3697537888.531073802.2752901294
+		popw.local.13
+
+		push.1177355171.3360333508.1386735730.1955848377
+		popw.local.14
+		push.4289716226.3144947240.2389855506.2980504791
+		popw.local.15
+
+		push.700321620.3453076438.893514690.606089263
+		popw.local.16
+		push.1748776417.3010055774.2869800056.504899685
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 132 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+		push.3890731577.457292971.40712529.388389916
+		popw.local.12
+		push.1347529561.2802179893.2869951897.1536817341
+		popw.local.13
+
+		push.673494723.324283176.3849768216.2055261317
+		popw.local.14
+		push.552859389.3708339056.4050877314.1674809457
+		popw.local.15
+
+		push.472671125.1675340871.2177502784.1352462753
+		popw.local.16
+		push.824501553.3874455310.1112455047.1694170026
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 133 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+		push.3624950584.1533899097.2055253179.501738020
+		popw.local.12
+		push.1103191670.2249743073.1880978773.2095022150
+		popw.local.13
+
+		push.1442644806.1621608139.140707456.3161654250
+		popw.local.14
+		push.335950514.1135760495.1364328874.3947845556
+		popw.local.15
+
+		push.1841716269.490644074.3774337637.1617012474
+		popw.local.16
+		push.1641185695.3561105575.224771478.1529809627
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 134 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+		push.3455615407.544460235.4283235531.2808734768
+		popw.local.12
+		push.1049157668.4048606552.3688805333.258041226
+		popw.local.13
+
+		push.3419321238.900548646.3171847505.1632871479
+		popw.local.14
+		push.3804313617.2702658574.2023258108.1830829785
+		popw.local.15
+
+		push.984937033.1984873974.4263065565.370796384
+		popw.local.16
+		push.1580754376.193995505.1955262665.213724934
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 135 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+		push.1230271679.2564534995.1538379360.3840376258
+		popw.local.12
+		push.2377642332.3105748288.658941737.3848287119
+		popw.local.13
+
+		push.814557639.4075164095.151506914.3802561407
+		popw.local.14
+		push.2363080104.1665441107.4066025515.2109204365
+		popw.local.15
+
+		push.1496576875.336569921.825260533.94158768
+		popw.local.16
+		push.3194892716.865637286.2765349307.108164572
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 136 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+		push.1975555664.2360794075.189404495.3125024026
+		popw.local.12
+		push.2352684375.2580774530.761384299.21029020
+		popw.local.13
+
+		push.2200447727.2501315221.1860524645.1009959694
+		popw.local.14
+		push.3460243181.3844888820.3233286192.3274794079
+		popw.local.15
+
+		push.53950763.2668380391.671613586.1336192787
+		popw.local.16
+		push.450251810.928424712.2703391777.2563140621
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 137 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+		push.3041706134.3145900667.4111924089.886247057
+		popw.local.12
+		push.655473077.1614452765.722266091.1198923528
+		popw.local.13
+
+		push.1203116301.1913917406.2929270809.4071001299
+		popw.local.14
+		push.3200544417.625568451.2335576650.1015301833
+		popw.local.15
+
+		push.2689806454.130000742.3723042676.1354646945
+		popw.local.16
+		push.2553685397.3154728855.3667551962.4069506276
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 138 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+		push.3700076716.3216215371.1540149976.228142684
+		popw.local.12
+		push.397252675.999419436.3770044718.3897020825
+		popw.local.13
+
+		push.3533937348.3275929629.1852009830.869635757
+		popw.local.14
+		push.505264395.1050751288.3878113355.770538218
+		popw.local.15
+
+		push.2241787128.2139579637.3433130217.3211648711
+		popw.local.16
+		push.2517263576.4042753670.1491020741.2895083617
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 139 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+		push.3540255069.2266015559.2472946683.683280022
+		popw.local.12
+		push.3041398650.3038364316.612250299.612905714
+		popw.local.13
+
+		push.458966165.67657828.2041041920.1381601645
+		popw.local.14
+		push.934840656.2316700091.2457126757.4182809874
+		popw.local.15
+
+		push.1261403671.3135159688.1630687470.106067293
+		popw.local.16
+		push.936002814.1759351054.1143478402.2932513211
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 140 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+		push.3827793999.2078345016.871864670.2918539937
+		popw.local.12
+		push.922459716.3353852483.3059868674.1426832883
+		popw.local.13
+
+		push.1390383913.4199578999.2591082506.792771445
+		popw.local.14
+		push.2182460110.501852113.2657791012.3755043103
+		popw.local.15
+
+		push.4197499478.2904628123.4089742274.1442998264
+		popw.local.16
+		push.3228405253.2904260154.649894961.147244772
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 141 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+		push.1104882810.1812522460.1450059043.2006763478
+		popw.local.12
+		push.72048536.2030351545.536540664.2426277382
+		popw.local.13
+
+		push.4245740544.2831738898.40501219.2379008093
+		popw.local.14
+		push.1710140178.3785613242.1278628340.845164682
+		popw.local.15
+
+		push.16111364.2864130042.1477126338.2330202939
+		popw.local.16
+		push.3774381613.2697887140.2639241439.2419218767
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 142 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+		push.217610691.1132890332.3920496761.838200308
+		popw.local.12
+		push.4016434047.3893954152.3169458504.658396597
+		popw.local.13
+
+		push.3626716624.3185634155.2696696971.256186495
+		popw.local.14
+		push.555067810.2946559994.956354080.1845864765
+		popw.local.15
+
+		push.3690810651.936539915.3704890400.4089034327
+		popw.local.16
+		push.1854176042.3823042056.1279545337.805818429
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 143 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+		push.1183512439.2499553057.457416044.736048145
+		popw.local.12
+		push.2227444990.3150820916.3856603633.2494141677
+		popw.local.13
+
+		push.2269876683.2132563350.2504038369.1970936459
+		popw.local.14
+		push.3998515147.3021581729.2074126042.1557537567
+		popw.local.15
+
+		push.1507692569.1281600628.3223766956.155357635
+		popw.local.16
+		push.2311239571.1476631995.3332104220.2566855325
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 144 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+		push.1657470326.859950440.227049692.1917647286
+		popw.local.12
+		push.3245761527.2090793224.3803694223.2872224638
+		popw.local.13
+
+		push.1137018281.1249747418.2360432081.531659163
+		popw.local.14
+		push.2915115111.1834088157.837320649.582846028
+		popw.local.15
+
+		push.3432352577.2325131202.1089364199.1837417496
+		popw.local.16
+		push.1560337992.2136371016.2971344595.2622522778
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 145 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+		push.4207096107.844498082.193986483.2315585509
+		popw.local.12
+		push.1740791300.178466676.759101613.557586419
+		popw.local.13
+
+		push.4269089657.159249346.2417143298.604633941
+		popw.local.14
+		push.1173922859.2530273468.3447249784.1676422960
+		popw.local.15
+
+		push.3564617578.3829789775.2903744190.3473714053
+		popw.local.16
+		push.2300631554.2768029517.3132875763.3442053077
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 146 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+		push.2067901395.282245567.974220059.2605553653
+		popw.local.12
+		push.2774053275.950774412.879879733.2514940752
+		popw.local.13
+
+		push.1933440197.255711093.4224281033.2793556242
+		popw.local.14
+		push.973326635.2314976903.1005179394.284801849
+		popw.local.15
+
+		push.1423054495.3705134590.778485318.3688557279
+		popw.local.16
+		push.3669844999.2194479677.2360827768.2740703811
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 147 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+		push.1771778487.1702483630.2520017881.2097599392
+		popw.local.12
+		push.4205730677.667119327.1264760824.1869604868
+		popw.local.13
+
+		push.2565524488.1213645335.1318888216.2320489479
+		popw.local.14
+		push.1574293651.3454274422.3072976757.3597577590
+		popw.local.15
+
+		push.130779285.1492730115.2024272269.3453860775
+		popw.local.16
+		push.4191400341.1202587609.947879290.2854050194
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 148 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+		push.2064218735.3605377863.176942435.710936868
+		popw.local.12
+		push.2563520090.1347964491.1614423994.1739478643
+		popw.local.13
+
+		push.1197206032.2513745684.3245150371.1718269768
+		popw.local.14
+		push.53387044.317289168.3379380930.2980798659
+		popw.local.15
+
+		push.3157582275.2937611601.4276275493.1179879697
+		popw.local.16
+		push.3549350156.23411.1804247676.2301467555
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 149 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+		push.4025725898.1821789688.2396070653.4255302914
+		popw.local.12
+		push.1930928871.4255666404.2691552099.386455188
+		popw.local.13
+
+		push.460012929.1774535072.2114302751.2459109992
+		popw.local.14
+		push.1516208887.3241099520.1470010580.2955634286
+		popw.local.15
+
+		push.2790064090.3566046262.1680493640.3773589374
+		popw.local.16
+		push.2222357263.86162422.3543097117.1668404676
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 150 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+		push.1622944700.2357953766.729038944.1466694589
+		popw.local.12
+		push.579443649.204398433.2134757350.3542208621
+		popw.local.13
+
+		push.1402673100.1665145998.2418303385.4102225222
+		popw.local.14
+		push.7922123.2772545079.2003728222.3187977222
+		popw.local.15
+
+		push.4016507243.292370172.1888368110.862290367
+		popw.local.16
+		push.1808123580.3848144968.637967900.3009040128
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 151 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+		push.1643073482.2839435546.3019355970.188646773
+		popw.local.12
+		push.2580400090.4004401094.791246640.3578852948
+		popw.local.13
+
+		push.2141131164.2390500499.4259384733.2509011624
+		popw.local.14
+		push.3964168896.3789324374.65590157.156407385
+		popw.local.15
+
+		push.1832846760.1874310065.4112770673.71782914
+		popw.local.16
+		push.1319304454.328624789.2915081368.2491623375
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 152 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+		push.2546084155.3608554673.2405328688.3971361475
+		popw.local.12
+		push.3000682049.2858438453.1944465110.1431805862
+		popw.local.13
+
+		push.2732390218.2694344811.479332761.1411019904
+		popw.local.14
+		push.381471743.1652457212.4054018291.1898221274
+		popw.local.15
+
+		push.2183317250.1176990790.985758808.3854368708
+		popw.local.16
+		push.991231597.940860021.3801054757.3892051235
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 153 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+		push.1414633309.2571998273.3448729772.2561368912
+		popw.local.12
+		push.2707033048.2856148546.1725453397.2459401074
+		popw.local.13
+
+		push.3724198387.970705117.2098511613.3553089727
+		popw.local.14
+		push.2235034310.3630461779.1062669979.348510416
+		popw.local.15
+
+		push.2238199733.973539500.1572884162.2220314349
+		popw.local.16
+		push.842536906.469178569.1234219247.154499569
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 154 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+		push.1989752537.2626584356.1453296241.3300145207
+		popw.local.12
+		push.1683716820.3717024419.2285627997.4269125309
+		popw.local.13
+
+		push.3475575137.3796718024.66691442.1778027685
+		popw.local.14
+		push.3747196075.2186333639.1195494790.3731492381
+		popw.local.15
+
+		push.948327796.3676807926.3017390535.956433714
+		popw.local.16
+		push.1134162676.1562574376.3190511781.1420389826
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 155 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+		push.3089564150.3751207063.1282659451.3150553535
+		popw.local.12
+		push.564534705.3590651950.648080079.119337249
+		popw.local.13
+
+		push.2957661592.1768446826.2073159635.273160305
+		popw.local.14
+		push.540420806.1085928370.3472400130.1311479721
+		popw.local.15
+
+		push.2773322276.4210519381.4031158241.1316466316
+		popw.local.16
+		push.969597978.4197815787.2549204570.2390660699
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 156 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+		push.724823211.1696035521.1405982363.1503913523
+		popw.local.12
+		push.1641588201.1997556269.3052383629.1417490188
+		popw.local.13
+
+		push.1907231098.3362427654.1388992075.3781051589
+		popw.local.14
+		push.1903256371.2986175708.2949448216.4191546126
+		popw.local.15
+
+		push.808987913.3741968100.1045223618.1007299885
+		popw.local.16
+		push.2243633778.1526749261.3382364361.4066010598
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 157 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+		push.1198933407.2333643671.1240413.4072937665
+		popw.local.12
+		push.2663798275.3749853823.4123467059.345469238
+		popw.local.13
+
+		push.2804006955.1477697650.3981985868.3585860031
+		popw.local.14
+		push.3356106588.747404536.2184439659.3126202264
+		popw.local.15
+
+		push.3620985093.3509816817.3835351948.569581106
+		popw.local.16
+		push.1413788852.3748821879.2803331137.2495568737
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 158 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+		push.4269063248.3405512655.3016657240.2334632081
+		popw.local.12
+		push.1020796908.3273942413.1102842203.3813857876
+		popw.local.13
+
+		push.942482521.2123259483.898690763.4248309983
+		popw.local.14
+		push.1443400350.2184489318.1358879432.884196765
+		popw.local.15
+
+		push.933616770.4280554689.1018855947.1685953442
+		popw.local.16
+		push.2475964213.1486635410.3696176718.399194739
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 159 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+		push.552117193.1382740006.3895393951.1754314637
+		popw.local.12
+		push.1213778273.1436093414.34586292.3970718009
+		popw.local.13
+
+		push.1483184174.1868917149.2696141113.4046771950
+		popw.local.14
+		push.1086151138.1666520193.4195531705.1681900111
+		popw.local.15
+
+		push.577715395.3484327043.1163258242.2312722803
+		popw.local.16
+		push.3175450897.354570379.1102206875.1183272488
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 160 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+		push.1315823684.2794440437.1791126631.1134914047
+		popw.local.12
+		push.3739359822.874169731.2210747310.2852570808
+		popw.local.13
+
+		push.965999638.3844643327.2205994417.3373054360
+		popw.local.14
+		push.2350525150.621595852.156133309.2217548599
+		popw.local.15
+
+		push.2132793259.1797137216.3995667102.3967195197
+		popw.local.16
+		push.63117983.1187521712.2688609646.909566848
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 161 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+		push.3399265666.3623759520.2842470626.767441890
+		popw.local.12
+		push.1906217998.229857777.880446017.4235385205
+		popw.local.13
+
+		push.2892217978.2244453941.1805654601.2085415298
+		popw.local.14
+		push.698220954.2320123396.3767549439.3133813121
+		popw.local.15
+
+		push.511154139.1639256147.3513875857.1404364344
+		popw.local.16
+		push.806597099.7405547.4096525630.1884454932
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 162 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+		push.1378492106.2513425548.2045927279.3609631116
+		popw.local.12
+		push.3623148261.3141457921.1110942374.1809199798
+		popw.local.13
+
+		push.2995245769.2542725840.2964742948.1219200045
+		popw.local.14
+		push.1431848240.1480682263.933038027.500897650
+		popw.local.15
+
+		push.2176753313.1653542029.1543323461.2096306219
+		popw.local.16
+		push.2626421069.3013923005.3999983932.3727120669
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 163 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+		push.1298864518.4123512033.2051052216.1319389080
+		popw.local.12
+		push.3427738026.2163458914.2534286542.670047644
+		popw.local.13
+
+		push.1541595784.1467679288.4093173307.1502371903
+		popw.local.14
+		push.4125514701.283189010.2302495078.3481125069
+		popw.local.15
+
+		push.540457411.244968516.2079562759.162079306
+		popw.local.16
+		push.564503032.3093958349.1701436582.508470974
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 164 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+		push.1849060659.1284433717.2438538713.1736679491
+		popw.local.12
+		push.3989935567.3764254773.1428435245.598748263
+		popw.local.13
+
+		push.4115073706.2043856024.3071963505.440821427
+		popw.local.14
+		push.2085293697.1556521465.1670665409.2946548387
+		popw.local.15
+
+		push.2480320038.1208633101.182733897.2462027731
+		popw.local.16
+		push.4245247200.1311108936.2234579946.701605203
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 165 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+		push.2226718651.1174910472.1549577981.2899960270
+		popw.local.12
+		push.2214697074.4042098324.1875823367.954527288
+		popw.local.13
+
+		push.2064128177.3765538787.3285321210.1088008546
+		popw.local.14
+		push.309065148.1211888862.2287834734.2226190713
+		popw.local.15
+
+		push.3095685296.2382988635.3764891871.2036557529
+		popw.local.16
+		push.3214402739.2260872620.428885723.1320317911
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 166 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+		push.1709796860.3123488407.1268848768.2788334963
+		popw.local.12
+		push.1550661127.4113136477.4129107867.3450727525
+		popw.local.13
+
+		push.964688560.2478710384.184439768.3049668021
+		popw.local.14
+		push.1786448347.3123252037.4142919317.2000593835
+		popw.local.15
+
+		push.135179130.405322578.123384097.3833149481
+		popw.local.16
+		push.817944084.2922799794.1965720193.3068454134
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 167 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+		push.3180824165.2796858421.390155025.3252239109
+		popw.local.12
+		push.3755274059.1093758680.2832778966.2707567368
+		popw.local.13
+
+		push.1882284178.2274240076.61356569.97975973
+		popw.local.14
+		push.1563901362.2462886146.1251013731.1913849350
+		popw.local.15
+
+		push.4163355696.2553824423.632882177.1460416309
+		popw.local.16
+		push.1887329780.3522056787.2697588105.2677053289
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 168 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+		push.2761635638.2501425637.1421115322.540961415
+		popw.local.12
+		push.2416868770.842982332.1897801874.336353303
+		popw.local.13
+
+		push.845017214.1525614536.2478474835.2882047916
+		popw.local.14
+		push.1605216604.3487841655.3672032306.1217923547
+		popw.local.15
+
+		push.248035252.1956053934.1482204716.202099685
+		popw.local.16
+		push.1180270768.4070856243.1019180653.1108013791
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 169 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+		push.2610024954.171445359.4131381121.2223600951
+		popw.local.12
+		push.633969611.652656590.3025194991.253256001
+		popw.local.13
+
+		push.3649368726.1189344453.1705257487.2248818897
+		popw.local.14
+		push.3135123011.791478914.3156881862.306857657
+		popw.local.15
+
+		push.2180509229.2331008552.1029181051.49527350
+		popw.local.16
+		push.130735258.4060142944.1883010749.3160979394
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 170 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+		push.3578703254.3489860685.3809209770.1491810965
+		popw.local.12
+		push.3516169663.1271621923.2492513716.832418194
+		popw.local.13
+
+		push.3513661688.2021908680.304851617.4004094745
+		popw.local.14
+		push.2358681903.3871874951.4039825782.1137970111
+		popw.local.15
+
+		push.2741865528.3612459500.2537950457.2064564966
+		popw.local.16
+		push.2410874676.4043533792.1401390958.574408037
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 171 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+		push.3945153907.42688053.1599561854.2104929750
+		popw.local.12
+		push.95781997.4160360877.1090830158.1089602625
+		popw.local.13
+
+		push.2227672957.1004174379.3282150805.2691638537
+		popw.local.14
+		push.3917916306.2676548023.1305427787.2591560018
+		popw.local.15
+
+		push.3282184936.709775722.1526202438.3115170250
+		popw.local.16
+		push.2448987925.3275442066.1827409637.1674290320
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 172 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+		push.2237692178.3745562400.1904627517.3550879148
+		popw.local.12
+		push.3133691620.2462573880.2523426974.1654057057
+		popw.local.13
+
+		push.4241419297.3200751746.1702646116.2102320562
+		popw.local.14
+		push.2635902487.4271308573.1055526533.2750425995
+		popw.local.15
+
+		push.1326606968.2762804126.2747960092.4198618395
+		popw.local.16
+		push.238305217.1585442315.415298656.2905300146
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 173 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+		push.949467963.3654938676.2261950315.3621369856
+		popw.local.12
+		push.3993795767.1140295863.1936656814.1879108671
+		popw.local.13
+
+		push.3923681703.3783117492.1987867447.2124922347
+		popw.local.14
+		push.3963400091.2804451292.291357235.1347715243
+		popw.local.15
+
+		push.2601190321.1827087234.3763719913.3386779367
+		popw.local.16
+		push.3496511508.3240977.2052137645.1216365629
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 174 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+		push.347758131.2042307323.3364394997.2868857603
+		popw.local.12
+		push.1644097626.1470481828.3583775446.1060206785
+		popw.local.13
+
+		push.3255039374.3683362559.2219244949.148516568
+		popw.local.14
+		push.4047902427.1627383396.2301165011.1662316042
+		popw.local.15
+
+		push.3576642928.1673782302.3520797747.1885172576
+		popw.local.16
+		push.1362574001.2459510299.2777836709.4172165059
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 175 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+		push.3760457677.3744585930.2980919435.3638455722
+		popw.local.12
+		push.4123952205.251004692.3428292584.737118408
+		popw.local.13
+
+		push.191957737.2156796861.2457730292.1459335571
+		popw.local.14
+		push.4126630232.2439936881.819384768.2755116977
+		popw.local.15
+
+		push.2855826582.1323044414.3685599927.2021328076
+		popw.local.16
+		push.1026626164.698929808.3550246064.1187279806
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 176 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+		push.3679361876.1786587470.3330253884.1614258177
+		popw.local.12
+		push.1171379260.195320030.4050995933.942701412
+		popw.local.13
+
+		push.2156930754.1454279754.2238516829.1477840259
+		popw.local.14
+		push.352574919.3948202420.92925261.77813632
+		popw.local.15
+
+		push.3585788122.1819876757.2092004150.677895715
+		popw.local.16
+		push.1064878524.3905951391.2860639113.271252031
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 177 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+		push.3260747829.505961830.964948814.1606163850
+		popw.local.12
+		push.1458468889.3623226609.4038826991.3454171911
+		popw.local.13
+
+		push.4208234474.2802769324.690338428.3857503376
+		popw.local.14
+		push.4273124973.4009083844.139471253.2324698278
+		popw.local.15
+
+		push.3783182816.2675786977.3362052445.3724241470
+		popw.local.16
+		push.3695043063.3720015305.832763561.404082991
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 178 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+		push.1458388276.3256615166.166790556.2414061174
+		popw.local.12
+		push.846307017.1042860320.55717745.1282736061
+		popw.local.13
+
+		push.2167892138.3364694040.896190836.1213716323
+		popw.local.14
+		push.3303669867.3334998183.3127375531.763491688
+		popw.local.15
+
+		push.2866583962.2942663523.3050012457.630862930
+		popw.local.16
+		push.1661239275.3726187141.1638625686.227416827
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 179 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+		push.536842472.3564942660.1625988705.3824486601
+		popw.local.12
+		push.271783886.669166123.1487292449.1525245500
+		popw.local.13
+
+		push.1283860101.1502550714.455316307.3455732793
+		popw.local.14
+		push.2135040285.3571659439.3746348982.1679301970
+		popw.local.15
+
+		push.375966150.4187197681.2316199144.4122857260
+		popw.local.16
+		push.3575442036.2293595514.872338064.660397928
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 180 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+		push.2620134969.158971595.1393095156.1886838778
+		popw.local.12
+		push.2618869420.4023564048.1136765549.2021684249
+		popw.local.13
+
+		push.2511445427.683260061.523237886.368897638
+		popw.local.14
+		push.3327815613.56105643.1560171414.2188376037
+		popw.local.15
+
+		push.4189016784.1386868487.2015805813.3093829931
+		popw.local.16
+		push.2489227148.2417209724.2527997172.2244008580
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 181 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+		push.2758940507.3572260954.1736307102.1446510083
+		popw.local.12
+		push.1350799915.4123118312.2235979054.637155520
+		popw.local.13
+
+		push.1488642755.1803035816.884628605.1607593277
+		popw.local.14
+		push.2988512250.1558815963.3977787377.558855054
+		popw.local.15
+
+		push.1855517426.1117565088.3496303175.3622632311
+		popw.local.16
+		push.2460265381.4144472402.1999209392.47540040
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 182 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+		push.357397228.2407199632.1152780213.526524990
+		popw.local.12
+		push.3531851127.127763693.3035754922.2010347478
+		popw.local.13
+
+		push.380174645.3572415106.3881554764.4086155489
+		popw.local.14
+		push.106692475.494865399.2350813721.2191490510
+		popw.local.15
+
+		push.902765376.1482768963.70200561.718195788
+		popw.local.16
+		push.2325780958.1404316001.1024012863.1753029313
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 183 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+		push.4120163719.208444573.3273066836.2396310581
+		popw.local.12
+		push.1991575676.3851010087.4252846179.749245841
+		popw.local.13
+
+		push.3239328829.390770388.3076568543.1159901950
+		popw.local.14
+		push.2422932427.1243854876.859155462.1114290235
+		popw.local.15
+
+		push.862089947.519164438.2477992711.1268333762
+		popw.local.16
+		push.2648568157.802486206.1844235730.1127006053
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 184 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+		push.2600871450.3694150655.2251812839.113681128
+		popw.local.12
+		push.1700774722.4049959931.1055892457.3152238957
+		popw.local.13
+
+		push.1306922071.92940236.1765659600.4246594444
+		popw.local.14
+		push.3187924916.786830645.3231598680.3698529334
+		popw.local.15
+
+		push.648011985.2894234737.829511402.3797767974
+		popw.local.16
+		push.762542982.1693412854.398831332.997153191
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 185 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+		push.2732300811.1034747874.1952067483.3840689472
+		popw.local.12
+		push.526779139.2360844429.1085958826.2079343349
+		popw.local.13
+
+		push.3379919812.902031332.4127234423.1068203296
+		popw.local.14
+		push.3936080342.4150463149.3104492125.859234643
+		popw.local.15
+
+		push.3405557562.4225516526.3753452237.3488373140
+		popw.local.16
+		push.3319977298.1001761551.954397555.697850973
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 186 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+		push.3466081709.2155866485.423378708.3584536917
+		popw.local.12
+		push.1100405854.1312685569.61228804.3777838166
+		popw.local.13
+
+		push.210886216.3516169055.1859673874.894345970
+		popw.local.14
+		push.1237506035.4265919547.2089424609.3941932843
+		popw.local.15
+
+		push.2966833882.2351683939.1111934998.3100990287
+		popw.local.16
+		push.686162940.2086455682.2696457207.3676608649
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 187 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+		push.3304653604.1672792160.3324660356.1546633361
+		popw.local.12
+		push.1368384392.2327397257.72244593.1700814592
+		popw.local.13
+
+		push.3174822453.991180681.2705927234.377884417
+		popw.local.14
+		push.1158199531.3799617076.3853631473.833763321
+		popw.local.15
+
+		push.920329661.1082979201.998203728.3163783243
+		popw.local.16
+		push.443574089.2513612014.451559263.1811553988
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 188 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+		push.3753579883.2697680033.1367299585.2733294006
+		popw.local.12
+		push.3995448026.1072833636.1591548871.178613484
+		popw.local.13
+
+		push.503468350.2737252546.1031061364.1487746185
+		popw.local.14
+		push.3918087802.5294091.1339402345.2713697084
+		popw.local.15
+
+		push.1047066571.3292039577.4112704125.3013510086
+		popw.local.16
+		push.3234620089.3791026977.3538719421.169647033
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 189 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+		push.1172824150.2938808110.836617547.2098338587
+		popw.local.12
+		push.121112172.394822179.1382539451.255974591
+		popw.local.13
+
+		push.2843153173.2952610112.1932654674.3072390569
+		popw.local.14
+		push.656256402.1350580952.3960259101.488937829
+		popw.local.15
+
+		push.2342702666.2735168124.2320052430.844345549
+		popw.local.16
+		push.709389494.1709536089.2626782382.2343598486
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 190 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+		push.3935157946.1580307507.2250644174.2111463341
+		popw.local.12
+		push.784744739.498279707.367361455.316954808
+		popw.local.13
+
+		push.3916925008.1869955556.3866251702.1520426086
+		popw.local.14
+		push.1107933401.1375155703.1786752218.3981357010
+		popw.local.15
+
+		push.3385810362.3330711099.4068064403.1184469162
+		popw.local.16
+		push.2686161319.689314721.2166867550.1840971114
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 191 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+		push.160317760.970965281.617450999.4247894070
+		popw.local.12
+		push.4232136298.500599656.1980254106.1401512210
+		popw.local.13
+
+		push.2408713695.1608465013.2938032522.3222242592
+		popw.local.14
+		push.2636379163.1876157952.91472819.1364457688
+		popw.local.15
+
+		push.270375959.87328024.2968835233.2210678258
+		popw.local.16
+		push.2937671341.1534065227.925069856.930630357
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 192 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+		push.2872698197.1090373982.4141452066.1105078949
+		popw.local.12
+		push.4116855273.3414195230.1707157191.2140451481
+		popw.local.13
+
+		push.3105661636.4165081031.2402686886.2704817268
+		popw.local.14
+		push.2009691811.2882546771.4134283004.2391646836
+		popw.local.15
+
+		push.2888603813.3943606262.3079889941.1050687071
+		popw.local.16
+		push.4119812715.2999452556.180875859.1322938549
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 193 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+		push.1213933469.1414913109.3762377620.2389861385
+		popw.local.12
+		push.1513135599.2589219924.2808858786.1625438931
+		popw.local.13
+
+		push.1413652451.2028688940.914536411.3663570513
+		popw.local.14
+		push.1359390184.540478134.1560717999.504399607
+		popw.local.15
+
+		push.743446139.1256465269.1505722664.807802512
+		popw.local.16
+		push.2281574884.3468109719.3811887925.618240864
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 194 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+		push.3750372195.2035230318.3416831941.601913095
+		popw.local.12
+		push.1842401186.770227603.2827187260.3227082663
+		popw.local.13
+
+		push.242037600.3789219983.902632400.1476221585
+		popw.local.14
+		push.835993623.237220582.2197896262.359783156
+		popw.local.15
+
+		push.2318448244.2408219374.53137671.2638019734
+		popw.local.16
+		push.4194594061.3046376037.615279429.2416563804
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 195 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+		push.3175147862.3728138803.1983610580.357121855
+		popw.local.12
+		push.4027599687.3801023292.1774418420.164578292
+		popw.local.13
+
+		push.3927628642.2923643026.2221540048.824001450
+		popw.local.14
+		push.2124369539.351079963.3666187436.2299416501
+		popw.local.15
+
+		push.2409085222.2422063545.1256650400.1518733434
+		popw.local.16
+		push.962742343.660648980.2700130693.2711707900
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 196 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+		push.746273230.2552422355.395058354.2609693913
+		popw.local.12
+		push.2828607444.444006774.1153496959.1413033905
+		popw.local.13
+
+		push.164954283.80506484.453749957.1446473025
+		popw.local.14
+		push.275398732.2538348840.2868690151.3827840943
+		popw.local.15
+
+		push.3074152882.2072717813.1590290827.2333139902
+		popw.local.16
+		push.3621729482.2930415939.2210283962.3497752647
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 197 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+		push.2794198664.533667712.761606379.1284702956
+		popw.local.12
+		push.1504096042.2812881928.1080060923.123366491
+		popw.local.13
+
+		push.2275477839.2837850480.1655960220.3845945523
+		popw.local.14
+		push.2463504785.749985839.1670927809.292870484
+		popw.local.15
+
+		push.3304257464.2537616956.3512623498.2126195581
+		popw.local.16
+		push.3006788464.3922936714.1990865200.2159906753
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 198 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+		push.43181145.4271512875.2992013953.537063912
+		popw.local.12
+		push.78198817.2773655847.289346104.4040893901
+		popw.local.13
+
+		push.1195938999.664763569.2142080281.1258390353
+		popw.local.14
+		push.1096473223.106254079.3522501426.4186953790
+		popw.local.15
+
+		push.1047209446.531143364.2798678993.1854873699
+		popw.local.16
+		push.922640438.3326491725.4148951913.1012599717
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 199 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+		push.1528193762.2689884256.1394603683.2276308131
+		popw.local.12
+		push.2113559319.2261662807.3965887726.35353300
+		popw.local.13
+
+		push.1566331759.3357417936.2272206374.787274229
+		popw.local.14
+		push.1371849441.2697974248.1265922011.1226939181
+		popw.local.15
+
+		push.297107756.3142666049.1608657079.2573568521
+		popw.local.16
+		push.729134313.2172017006.109797606.507719978
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 200 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+		push.2009071546.2341486324.2515248183.2860729139
+		popw.local.12
+		push.4135990155.2603221192.1058306199.1888557965
+		popw.local.13
+
+		push.1367445881.2565299343.3139984011.1160618095
+		popw.local.14
+		push.2965608115.4081526807.48830403.4014754019
+		popw.local.15
+
+		push.297587544.794473728.3611244036.4070224159
+		popw.local.16
+		push.2907005800.3502237281.653703936.929946483
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 201 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+		push.3937457711.4137541527.992063813.3193654052
+		popw.local.12
+		push.2755496574.3519788633.919533222.2648912988
+		popw.local.13
+
+		push.4092280765.294278980.2162967043.481098861
+		popw.local.14
+		push.777643555.1501562020.3846194279.1527473716
+		popw.local.15
+
+		push.511275850.3175558769.59135097.1287659454
+		popw.local.16
+		push.4095764453.1533214482.2510953440.1704507751
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 202 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+		push.1899817798.570856509.2225898115.1051650494
+		popw.local.12
+		push.357330906.2785149658.606444315.2714856291
+		popw.local.13
+
+		push.1879631097.952270060.2774695162.3321241734
+		popw.local.14
+		push.749411667.3913905385.907503122.3793819610
+		popw.local.15
+
+		push.3359107157.3007700557.3168195456.4285623041
+		popw.local.16
+		push.3766550217.457602604.1788386326.4160827950
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 203 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+		push.2791808198.843805962.1860090059.2571212279
+		popw.local.12
+		push.1185184074.3389154792.2460424441.2513942548
+		popw.local.13
+
+		push.2302826707.927635057.3373136182.238398822
+		popw.local.14
+		push.1535892432.3333248629.2043511247.2996391032
+		popw.local.15
+
+		push.2262573183.4251152174.1743670167.868382033
+		popw.local.16
+		push.1391991968.418968215.1137955108.1712255338
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 204 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+		push.3796866466.3100978440.1642197136.4001983926
+		popw.local.12
+		push.3523982667.324696846.3502414063.1131793216
+		popw.local.13
+
+		push.2703094512.2651683439.904102291.626474857
+		popw.local.14
+		push.1993726107.525257035.844979478.3908804621
+		popw.local.15
+
+		push.960803586.695656961.3591234774.663516183
+		popw.local.16
+		push.1524339650.3515735467.3907989411.1648656604
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 205 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+		push.1753919648.3472464120.3151257311.3379514080
+		popw.local.12
+		push.1930059599.3973734754.3106682314.3979222393
+		popw.local.13
+
+		push.2284708863.1803858496.3545549739.1363666819
+		popw.local.14
+		push.1019404486.1111487779.537609494.3812769894
+		popw.local.15
+
+		push.3127807599.3026904391.1976284050.1557420788
+		popw.local.16
+		push.3677926886.1599588132.2158810040.1055178879
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 206 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+		push.3005200779.341834517.3731102939.152763094
+		popw.local.12
+		push.3042735058.2851463274.777765340.4221346227
+		popw.local.13
+
+		push.2822804352.935637314.1440711465.507956193
+		popw.local.14
+		push.2549414397.4105828035.3476228308.2978303903
+		popw.local.15
+
+		push.2710768741.1616025433.546954416.3238254469
+		popw.local.16
+		push.3922987158.108814019.3777734856.1485000560
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 207 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+		push.944386678.2591633282.2504235071.567042626
+		popw.local.12
+		push.3046272278.358626846.3829258050.465812374
+		popw.local.13
+
+		push.1620766189.966940869.3245372610.1886152893
+		popw.local.14
+		push.3072009580.3143783003.1329858866.2689904133
+		popw.local.15
+
+		push.1916025323.3701044413.1319585839.581894166
+		popw.local.16
+		push.3644518502.3732852513.2357128332.676331823
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 208 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+		push.2678622688.3066821601.3289052211.1248206257
+		popw.local.12
+		push.2745366506.788658156.4242112957.1630977282
+		popw.local.13
+
+		push.1351166256.4196881392.4253428350.691124095
+		popw.local.14
+		push.1349780974.3226205716.1817358996.4235352499
+		popw.local.15
+
+		push.3634193660.3190442493.882081595.3933680047
+		popw.local.16
+		push.448452926.3450985026.545514550.1201359236
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 209 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+		push.3709690563.549902884.2242194635.3739298855
+		popw.local.12
+		push.1799760839.3078682677.257258660.3762238685
+		popw.local.13
+
+		push.2563189470.1125728355.514083020.1124353541
+		popw.local.14
+		push.1582405283.1264767328.2941904606.3536469041
+		popw.local.15
+
+		push.3731963929.2323396206.2647609854.3694143483
+		popw.local.16
+		push.1137057888.3435405761.3469613410.4027296466
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 210 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+		push.4199822673.1305699101.2627451673.1788150534
+		popw.local.12
+		push.2573329529.3620885480.3216520821.1841945980
+		popw.local.13
+
+		push.2113111837.3665021265.3786338608.2298153658
+		popw.local.14
+		push.2749272991.475310084.1967848598.3955805843
+		popw.local.15
+
+		push.169444817.3905741579.2645439209.3030101236
+		popw.local.16
+		push.3232692885.874595634.1944852801.2608688031
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 211 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+		push.961640246.51821053.138878530.390826772
+		popw.local.12
+		push.4146647688.321033063.3510968976.1278862182
+		popw.local.13
+
+		push.3366766502.395764187.954202289.3986851759
+		popw.local.14
+		push.2883001739.3082794671.893382718.1944452668
+		popw.local.15
+
+		push.4043525414.2412876685.760012657.2626059230
+		popw.local.16
+		push.782566951.2414451749.4244166595.352177853
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 212 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+		push.1148365313.1962968134.3158968015.3323963493
+		popw.local.12
+		push.404697502.4222226879.2229875264.2115445635
+		popw.local.13
+
+		push.1018428010.4294608175.2915772725.371340867
+		popw.local.14
+		push.1666337119.1857063562.1929182677.3511332175
+		popw.local.15
+
+		push.162436098.2772186275.1292462380.143237952
+		popw.local.16
+		push.369979095.3342424120.2515577834.1403293456
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 213 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+		push.3424082514.4080715965.3000272381.3577648268
+		popw.local.12
+		push.1678891300.819802084.920288413.3498333264
+		popw.local.13
+
+		push.2420714952.2494664294.724965712.1669008241
+		popw.local.14
+		push.3961653970.3838159997.2970253599.551021872
+		popw.local.15
+
+		push.2694474090.2557326045.3137518526.1240269207
+		popw.local.16
+		push.234676145.256884026.52202501.2637262269
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 214 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+		push.1540982819.563906995.2621622873.2673274228
+		popw.local.12
+		push.2356036762.1457047634.512843067.1519128330
+		popw.local.13
+
+		push.4061702105.2478974976.3800309872.4008860087
+		popw.local.14
+		push.1181699429.728245551.2540259105.2906420700
+		popw.local.15
+
+		push.2816355724.2744258411.3202744668.273468686
+		popw.local.16
+		push.3268333994.571220065.3904133961.3395645609
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 215 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+		push.4139238349.1361599354.37455998.3200970598
+		popw.local.12
+		push.1010136976.1404985580.2472469719.2305540222
+		popw.local.13
+
+		push.2276306899.4273564593.3138368756.2245223051
+		popw.local.14
+		push.163846830.2984106568.2436399119.723651998
+		popw.local.15
+
+		push.1391979527.3517663363.2608650452.500316234
+		popw.local.16
+		push.1441413985.3953059213.1252344493.2181548730
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 216 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+		push.2723511710.785436091.4285435836.2664086282
+		popw.local.12
+		push.1560499650.1461437121.1617265066.3947089685
+		popw.local.13
+
+		push.1088185355.755614813.754609756.489027891
+		popw.local.14
+		push.2374461209.724323246.358319328.2136780222
+		popw.local.15
+
+		push.701699999.2490924057.1701631579.1848505821
+		popw.local.16
+		push.2063127465.2224776754.1565274094.3545492585
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 217 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+		push.393331917.1230104509.1986738288.684678892
+		popw.local.12
+		push.80742189.1742470463.2487963811.542276317
+		popw.local.13
+
+		push.247839968.1766270459.2199432616.2631364854
+		popw.local.14
+		push.2500058319.234254723.3250006028.1217549160
+		popw.local.15
+
+		push.3550263079.401677998.130708854.1190102107
+		popw.local.16
+		push.1300072616.4201990711.2009407974.3082548322
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 218 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+		push.3057766773.4023342987.1295014553.1623217457
+		popw.local.12
+		push.111634516.1421316653.1439001701.3091605826
+		popw.local.13
+
+		push.3480440260.3405352696.2661974644.468622153
+		popw.local.14
+		push.260641556.2496893679.3476882565.3732026979
+		popw.local.15
+
+		push.2814366575.338306934.3219690755.1730228237
+		popw.local.16
+		push.469751094.3697464372.1551273632.573613102
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 219 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+		push.3842938795.4178807336.2829082774.3289599419
+		popw.local.12
+		push.2798859732.1220532324.2329473049.133202497
+		popw.local.13
+
+		push.4069356548.2469839957.3755579156.283024429
+		popw.local.14
+		push.3016354591.44723240.2457111193.1354843961
+		popw.local.15
+
+		push.1140131025.2664272694.4042707573.1300593223
+		popw.local.16
+		push.958277381.365702046.4274926853.2376482223
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 220 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+		push.464777089.1461079999.2740814415.1187689149
+		popw.local.12
+		push.960838446.1836940398.424939287.2849959135
+		popw.local.13
+
+		push.1005648548.772407716.4133727180.4111104471
+		popw.local.14
+		push.1418563290.1315618897.1933499394.1508391442
+		popw.local.15
+
+		push.3662878119.3108233390.685642640.2625539939
+		popw.local.16
+		push.619358414.664394475.511703192.920858191
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 221 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+		push.3855110489.3147500082.1522595904.3128843599
+		popw.local.12
+		push.1651729448.3731468053.2542904658.689898465
+		popw.local.13
+
+		push.4289112270.68670616.23969732.3865912684
+		popw.local.14
+		push.1759826544.316908183.3833032603.3731983950
+		popw.local.15
+
+		push.1846915631.2480097620.3577698349.1218544893
+		popw.local.16
+		push.2124892802.2899790009.2373233225.1730219547
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 222 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+		push.3865600976.603315528.3245510671.111278871
+		popw.local.12
+		push.632279119.1370910167.4039663956.719823411
+		popw.local.13
+
+		push.3150505212.4267463796.2459992470.3411277296
+		popw.local.14
+		push.318687452.3388583126.300732715.425100883
+		popw.local.15
+
+		push.1275201972.1305465818.3683011006.1446705965
+		popw.local.16
+		push.3346616811.3216959112.2078620749.2753226745
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 223 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+		push.2341314972.3300661555.3892604075.2474469554
+		popw.local.12
+		push.3438186533.3198272125.3341330868.1686941612
+		popw.local.13
+
+		push.2837592290.204070225.1406493533.1942656126
+		popw.local.14
+		push.3957186729.966814106.992304085.139003780
+		popw.local.15
+
+		push.2014404186.1887722909.2317691624.1350491520
+		popw.local.16
+		push.1283706606.3295423973.3568559575.1861829897
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  # process bit 224 of scalar
+  dup
+  u32shr.0
+  push.1
+  u32and
+
+  if.true
+		push.2981892650.2535214426.1915130.2331001822
+		popw.local.12
+		push.567437848.2995526766.2847237315.2622486040
+		popw.local.13
+
+		push.1215951813.877552417.1465680632.3361307245
+		popw.local.14
+		push.2613008707.2408629383.782285353.2614556985
+		popw.local.15
+
+		push.2460030714.1975634687.4270931590.488120361
+		popw.local.16
+		push.2927900728.1787920961.3664883545.2899562836
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 225 of scalar
+  dup
+  u32shr.1
+  push.1
+  u32and
+
+  if.true
+		push.166152820.126492444.3378668395.3728748438
+		popw.local.12
+		push.4110198145.265313956.1030822644.3157944671
+		popw.local.13
+
+		push.3638450560.358157191.3656970576.3929909964
+		popw.local.14
+		push.2622345671.3598831914.3446802864.848772170
+		popw.local.15
+
+		push.871910711.3417036522.3716385505.11888219
+		popw.local.16
+		push.1550977805.4289205885.444496993.1310459352
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 226 of scalar
+  dup
+  u32shr.2
+  push.1
+  u32and
+
+  if.true
+		push.2960453830.2210002259.1041747012.1992207679
+		popw.local.12
+		push.3511077045.391731676.2114939200.1162785720
+		popw.local.13
+
+		push.2930006168.3054251558.2078032525.3244059987
+		popw.local.14
+		push.2536534403.505612747.2062700618.3027380143
+		popw.local.15
+
+		push.3522965948.764856879.593559903.3828491558
+		popw.local.16
+		push.2544895281.1372106970.607553643.1563159011
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 227 of scalar
+  dup
+  u32shr.3
+  push.1
+  u32and
+
+  if.true
+		push.4087716062.2668216568.526152869.888742082
+		popw.local.12
+		push.473050634.1327384209.1142353387.380473373
+		popw.local.13
+
+		push.2434216359.496275057.1933866306.1803642124
+		popw.local.14
+		push.1347635321.88934206.841531409.3640535427
+		popw.local.15
+
+		push.1303125934.658550511.3729257464.449156268
+		popw.local.16
+		push.3036687300.1450173606.3975698908.1522027464
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 228 of scalar
+  dup
+  u32shr.4
+  push.1
+  u32and
+
+  if.true
+		push.32854073.2878296021.3561173503.3952815453
+		popw.local.12
+		push.435404112.528732176.382744961.1292144435
+		popw.local.13
+
+		push.3295925767.3946554521.1314482235.1870569031
+		popw.local.14
+		push.22636217.778760472.3049304537.725737798
+		popw.local.15
+
+		push.3210442343.693589582.3463222115.3295249715
+		popw.local.16
+		push.3034026076.3366514620.2160857415.3009457335
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 229 of scalar
+  dup
+  u32shr.5
+  push.1
+  u32and
+
+  if.true
+		push.207475880.467262689.1819604680.1583971742
+		popw.local.12
+		push.3937302361.737404085.4190399179.479949600
+		popw.local.13
+
+		push.2026878265.2908214774.3812050392.1297388559
+		popw.local.14
+		push.790274957.3591717566.1047017917.1041308951
+		popw.local.15
+
+		push.1947392460.1884313194.2173431365.3204094193
+		popw.local.16
+		push.2985226199.2248995759.457946349.1557038245
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 230 of scalar
+  dup
+  u32shr.6
+  push.1
+  u32and
+
+  if.true
+		push.1327974982.1428826325.3546421227.1266067080
+		popw.local.12
+		push.1016784963.410975754.224598369.2580931274
+		popw.local.13
+
+		push.2495624436.1647388031.1511859266.280173054
+		popw.local.14
+		push.2456973078.2128068043.2059065613.1157878633
+		popw.local.15
+
+		push.2713474275.782135120.2053262251.3868711215
+		popw.local.16
+		push.4004524983.4174461079.3988751163.156028962
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 231 of scalar
+  dup
+  u32shr.7
+  push.1
+  u32and
+
+  if.true
+		push.2086866628.3272630700.4108735625.295045197
+		popw.local.12
+		push.2309280304.3198409078.1202556162.700149846
+		popw.local.13
+
+		push.1788926764.2139295993.4189083365.3900432388
+		popw.local.14
+		push.770847453.783940588.3137890895.1383720232
+		popw.local.15
+
+		push.4137726641.829881322.1007667761.3831585089
+		popw.local.16
+		push.321435440.1673620386.3066610418.642630809
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 232 of scalar
+  dup
+  u32shr.8
+  push.1
+  u32and
+
+  if.true
+		push.624042286.3813467983.4046361439.1144938196
+		popw.local.12
+		push.1542529012.3920563771.3459154938.773685725
+		popw.local.13
+
+		push.3479144599.1082334498.2530672539.205485172
+		popw.local.14
+		push.542557784.4144894945.2539825585.48094730
+		popw.local.15
+
+		push.12546364.982720382.3225927904.1347277555
+		popw.local.16
+		push.1336310405.1425090978.333090010.3184174827
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 233 of scalar
+  dup
+  u32shr.9
+  push.1
+  u32and
+
+  if.true
+		push.1944122387.1246899064.3398560350.4021755929
+		popw.local.12
+		push.1055578266.82611738.3651300217.1308391227
+		popw.local.13
+
+		push.159696631.1267857207.1158643478.1694566227
+		popw.local.14
+		push.834094117.528954524.1473403046.1504553596
+		popw.local.15
+
+		push.571084896.2664177070.1203162646.1542631252
+		popw.local.16
+		push.1918978714.3948082086.2498028497.3837142776
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 234 of scalar
+  dup
+  u32shr.10
+  push.1
+  u32and
+
+  if.true
+		push.788550021.1382601951.2554306479.3575808578
+		popw.local.12
+		push.3965394424.410154417.3538308522.1717240069
+		popw.local.13
+
+		push.459952549.2220102209.1285588733.4209046487
+		popw.local.14
+		push.2258770410.3759763491.3650017203.744570486
+		popw.local.15
+
+		push.3318792945.4120823233.1754638116.282802467
+		popw.local.16
+		push.3770223320.2443982963.3790433734.1492334047
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 235 of scalar
+  dup
+  u32shr.11
+  push.1
+  u32and
+
+  if.true
+		push.2456990921.3490595374.2440218892.185657090
+		popw.local.12
+		push.4022887874.3403222840.159883978.1398586648
+		popw.local.13
+
+		push.1719659685.449596210.1812659793.1211636195
+		popw.local.14
+		push.2454272254.2759588628.1899557210.2792843025
+		popw.local.15
+
+		push.2556246659.92046245.3653694776.2204048581
+		popw.local.16
+		push.3053492399.3234452290.3725204268.3082597979
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 236 of scalar
+  dup
+  u32shr.12
+  push.1
+  u32and
+
+  if.true
+		push.3598304296.1678631941.500566584.1639362574
+		popw.local.12
+		push.529533830.641169704.3930210021.2977723362
+		popw.local.13
+
+		push.1625996265.836178867.3784638064.140279558
+		popw.local.14
+		push.3812010854.2404766051.490309801.3215846786
+		popw.local.15
+
+		push.736454246.2397184556.890213241.2975327423
+		popw.local.16
+		push.3897978566.2467883603.1025626003.3134316404
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 237 of scalar
+  dup
+  u32shr.13
+  push.1
+  u32and
+
+  if.true
+		push.694248678.2208979821.2467480025.2867378887
+		popw.local.12
+		push.3863856840.2435457769.2371609754.3264611457
+		popw.local.13
+
+		push.1053158028.1666660416.1208633703.3234466328
+		popw.local.14
+		push.1038773072.1920588852.1257037570.1001181507
+		popw.local.15
+
+		push.3933715661.3963583371.878384267.3775858351
+		popw.local.16
+		push.2225412875.2928183305.1298488813.761888910
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 238 of scalar
+  dup
+  u32shr.14
+  push.1
+  u32and
+
+  if.true
+		push.2866089984.1824562789.3963157458.3758632050
+		popw.local.12
+		push.3683708503.3675594325.1617746195.3389854201
+		popw.local.13
+
+		push.3287628350.3129624068.525968774.2687896166
+		popw.local.14
+		push.3944558367.2803630483.1001194909.2612394886
+		popw.local.15
+
+		push.1967622689.1067891404.789799845.1906378354
+		popw.local.16
+		push.3522173991.2023314688.337772967.3390295520
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 239 of scalar
+  dup
+  u32shr.15
+  push.1
+  u32and
+
+  if.true
+		push.2491695632.1837210206.1833290135.1771847585
+		popw.local.12
+		push.3375098642.646313020.1794406009.2432931828
+		popw.local.13
+
+		push.2865456065.3704137580.3335499609.2096130576
+		popw.local.14
+		push.369895413.3638006788.3180312665.852362182
+		popw.local.15
+
+		push.2013116127.942897994.521384611.3818734666
+		popw.local.16
+		push.2635234702.248663915.1231597263.3199395814
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 240 of scalar
+  dup
+  u32shr.16
+  push.1
+  u32and
+
+  if.true
+		push.1039953386.4252472174.947949313.61819516
+		popw.local.12
+		push.3467610694.2330225310.3594111511.727250670
+		popw.local.13
+
+		push.997860002.2213288659.3778419282.1398914528
+		popw.local.14
+		push.3666167054.3859872276.1777208133.425280949
+		popw.local.15
+
+		push.3696765434.2214283621.522385123.1288882766
+		popw.local.16
+		push.1526077311.2666406927.1430060802.297533935
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 241 of scalar
+  dup
+  u32shr.17
+  push.1
+  u32and
+
+  if.true
+		push.4063583217.465614150.3479138163.3385406759
+		popw.local.12
+		push.817961294.233589856.3957239612.215427003
+		popw.local.13
+
+		push.3765662067.2456443598.847343643.2448510023
+		popw.local.14
+		push.3348224685.3067161788.3313004782.2588581966
+		popw.local.15
+
+		push.1362452159.2118801839.3206811157.2633066603
+		popw.local.16
+		push.590932232.3439296894.2929528507.2541614374
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 242 of scalar
+  dup
+  u32shr.18
+  push.1
+  u32and
+
+  if.true
+		push.3144493745.2381952902.2629256137.2857567580
+		popw.local.12
+		push.1249714618.745770454.153252740.2819930461
+		popw.local.13
+
+		push.2101402377.268059336.3624308985.3465908484
+		popw.local.14
+		push.1867739315.41237985.2038363597.2440212436
+		popw.local.15
+
+		push.2531269453.256614732.315908841.152364702
+		popw.local.16
+		push.1912206721.1463429452.3613798737.27046412
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 243 of scalar
+  dup
+  u32shr.19
+  push.1
+  u32and
+
+  if.true
+		push.1976086277.180504913.1530408794.1459183005
+		popw.local.12
+		push.104013554.1758500829.3420551470.4017437352
+		popw.local.13
+
+		push.806461130.3624581514.2911627493.3192496244
+		popw.local.14
+		push.2381579073.4129492154.3430521627.2014044312
+		popw.local.15
+
+		push.900860937.3301129074.104737844.1761853537
+		popw.local.16
+		push.1406194949.797375917.4197616069.73120315
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 244 of scalar
+  dup
+  u32shr.20
+  push.1
+  u32and
+
+  if.true
+		push.833904658.2913879953.3083685625.3003126163
+		popw.local.12
+		push.972964336.1343764905.1839974576.2572304389
+		popw.local.13
+
+		push.1646328101.1156880648.1150213804.3195028175
+		popw.local.14
+		push.1388646176.451875476.3347613652.2311582805
+		popw.local.15
+
+		push.1103730782.1836000606.3578579675.4135321180
+		popw.local.16
+		push.374212451.1344010413.3803115775.1995055872
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 245 of scalar
+  dup
+  u32shr.21
+  push.1
+  u32and
+
+  if.true
+		push.593823559.3592854855.213157084.829358460
+		popw.local.12
+		push.2413437811.4091633862.4236386153.4097743837
+		popw.local.13
+
+		push.1675201847.2473958234.1620101697.1831612855
+		popw.local.14
+		push.3992973367.2165149480.2506500644.2182645161
+		popw.local.15
+
+		push.1213798187.3810118122.3504956936.3007403676
+		popw.local.16
+		push.1092410868.1923897824.4285951771.2731199034
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 246 of scalar
+  dup
+  u32shr.22
+  push.1
+  u32and
+
+  if.true
+		push.726578974.4271386481.664798730.2697487178
+		popw.local.12
+		push.4288982374.1217574074.2438325053.1113015771
+		popw.local.13
+
+		push.651324272.4179278148.3433441038.2462280092
+		popw.local.14
+		push.1679381327.2523859344.3072468730.3524156261
+		popw.local.15
+
+		push.1820294664.3746044143.4125010121.2748068242
+		popw.local.16
+		push.182141876.3946645722.2341983359.3819303925
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 247 of scalar
+  dup
+  u32shr.23
+  push.1
+  u32and
+
+  if.true
+		push.1195395795.847173656.1042229407.2353048631
+		popw.local.12
+		push.3350594128.3474745972.613125519.2325069777
+		popw.local.13
+
+		push.1534805690.2618857725.3635522397.3957448775
+		popw.local.14
+		push.2755468688.3198554212.4084634815.1110277604
+		popw.local.15
+
+		push.3052656681.1734130525.1880055269.9702456
+		popw.local.16
+		push.3016661756.1200649498.2634850411.2747110743
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 248 of scalar
+  dup
+  u32shr.24
+  push.1
+  u32and
+
+  if.true
+		push.149847018.43710904.573475438.400924673
+		popw.local.12
+		push.1309563026.2185586142.1795152983.3760278552
+		popw.local.13
+
+		push.254103738.3976447841.1058597257.3095710914
+		popw.local.14
+		push.405048047.3452456883.4267489721.4202926471
+		popw.local.15
+
+		push.2192058477.3713811608.1874616361.255158776
+		popw.local.16
+		push.2078975623.3619671174.3899400560.2278612219
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 249 of scalar
+  dup
+  u32shr.25
+  push.1
+  u32and
+
+  if.true
+		push.2873818992.560017005.1390537144.642877591
+		popw.local.12
+		push.3723744963.1747847880.3310452633.287120923
+		popw.local.13
+
+		push.3640696437.2333975126.1615022893.2504190400
+		popw.local.14
+		push.2448680816.3412922716.3327752223.2373494510
+		popw.local.15
+
+		push.2518000253.3024655185.1574652291.1534474891
+		popw.local.16
+		push.3456486173.3694082533.2328185985.2920466896
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 250 of scalar
+  dup
+  u32shr.26
+  push.1
+  u32and
+
+  if.true
+		push.3936742919.2772104824.1196829250.1483635998
+		popw.local.12
+		push.869397318.93253300.3475188449.1370550567
+		popw.local.13
+
+		push.845534863.4292867044.310255275.3021409946
+		popw.local.14
+		push.2912786659.1744005957.3445828053.1075248618
+		popw.local.15
+
+		push.417790438.2317439352.3958708618.1110650634
+		popw.local.16
+		push.2328084612.418074529.1301558259.1427548481
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 251 of scalar
+  dup
+  u32shr.27
+  push.1
+  u32and
+
+  if.true
+		push.2983034454.2629555476.1952408093.4166516135
+		popw.local.12
+		push.3459834965.3557149523.3355988002.212343495
+		popw.local.13
+
+		push.371813147.4208145029.1144509954.2115803330
+		popw.local.14
+		push.13657435.466709090.2331149592.3083955378
+		popw.local.15
+
+		push.550748983.1200583051.3108496349.1708525255
+		popw.local.16
+		push.3408819858.13908515.2830929943.1925067160
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 252 of scalar
+  dup
+  u32shr.28
+  push.1
+  u32and
+
+  if.true
+		push.3164290634.2510017135.1351906398.275052315
+		popw.local.12
+		push.3768343242.327112700.2467568403.1541255891
+		popw.local.13
+
+		push.1321637484.1327030418.2902000148.4053141646
+		popw.local.14
+		push.3565840709.2591895807.2473095747.4046137811
+		popw.local.15
+
+		push.2825534215.1305880981.842187130.934957739
+		popw.local.16
+		push.4095046996.2141155988.1989873639.1098634363
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 253 of scalar
+  dup
+  u32shr.29
+  push.1
+  u32and
+
+  if.true
+		push.1360840567.3731071105.615689712.1958952143
+		popw.local.12
+		push.1484680481.1136445883.4106450200.2612850720
+		popw.local.13
+
+		push.2618960121.3277112134.2548144913.2302900082
+		popw.local.14
+		push.637941066.4262787880.2876205873.3838430350
+		popw.local.15
+
+		push.1499295070.3971437743.2217725047.3276766074
+		popw.local.16
+		push.4246773447.3551240214.3835261861.215608593
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 254 of scalar
+  dup
+  u32shr.30
+  push.1
+  u32and
+
+  if.true
+		push.2181186994.1882380144.1948365018.2310826502
+		popw.local.12
+		push.3919977144.392046710.1215837599.1895884648
+		popw.local.13
+
+		push.2840054024.3362847970.549055994.1698803586
+		popw.local.14
+		push.2764786988.2255507265.534201118.1268406717
+		popw.local.15
+
+		push.949930655.1858648483.3255479703.636270793
+		popw.local.16
+		push.3321753728.3417442410.95544364.560677759
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  # process bit 255 of scalar
+  dup
+  u32shr.31
+  push.1
+  u32and
+
+  if.true
+		push.2518893645.1449684363.4238272990.1568923791
+		popw.local.12
+		push.1486287845.3004908234.1106597725.778081023
+		popw.local.13
+
+		push.112682241.1539449350.22356095.833785547
+		popw.local.14
+		push.3795524707.3432807938.3464672759.1770073772
+		popw.local.15
+
+		push.2390137912.1282011242.2190683269.3442419054
+		popw.local.16
+		push.1767015067.3527058907.3725831105.456741272
+		popw.local.17
+
+    push.env.locaddr.11
+    push.env.locaddr.10
+    push.env.locaddr.9
+    push.env.locaddr.8
+    push.env.locaddr.7
+    push.env.locaddr.6
+
+    push.env.locaddr.17
+    push.env.locaddr.16
+    push.env.locaddr.15
+    push.env.locaddr.14
+    push.env.locaddr.13
+    push.env.locaddr.12
+
+    push.env.locaddr.5
+    push.env.locaddr.4
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.point_addition
+
+    dropw
+    drop
+    drop
+
+    pushw.local.6
+    popw.local.0
+    pushw.local.7
+    popw.local.1
+
+    pushw.local.8
+    popw.local.2
+    pushw.local.9
+    popw.local.3
+
+    pushw.local.10
+    popw.local.4
+    pushw.local.11
+    popw.local.5
+  end
+
+  drop
+
+  dup
+  pushw.local.0
+  movup.4
+  popw.mem          # write x[0..4] to memory
+
+  dup.1
+  pushw.local.1
+  movup.4
+  popw.mem          # write x[4..8] to memory
+
+  dup.2
+  pushw.local.2
+  movup.4
+  popw.mem          # write y[0..4] to memory
+
+  dup.3
+  pushw.local.3
+  movup.4
+  popw.mem          # write y[4..8] to memory
+
+  dup.4
+  pushw.local.4
+  movup.4
+  popw.mem          # write z[0..4] to memory
+
+  dup.5
+  pushw.local.5
+  movup.4
+  popw.mem          # write z[4..8] to memory
 end
 "),
 // ----- std::math::u256 --------------------------------------------------------------------------


### PR DESCRIPTION
Given a 256 -bit scalar, this routine computes elliptic curve point, obtained by multiplying group identity point (0, 1, 0) by scalar.

- For worst case scenario i.e. all 256 -bits of scalar are set, required VM cycles for point multiplication: **8,929,463**
- While for some random 256 -bit scalar, cost of execution of this routine: **4,327,953**